### PR TITLE
feat: Clip instantiation model (name+package+version) + Registry integration (#22)

### DIFF
--- a/cmd/pinix/main.go
+++ b/cmd/pinix/main.go
@@ -29,6 +29,8 @@ func execute() error {
 		"mcp":        {},
 		"remove":     {},
 		"list":       {},
+		"search":     {},
+		"publish":    {},
 		"help":       {},
 		"completion": {},
 	}
@@ -64,6 +66,8 @@ func newRootCommand() *cobra.Command {
 	rootCmd.AddCommand(newMCPCommand(&serverURL, &hubToken))
 	rootCmd.AddCommand(newRemoveCommand(&serverURL, &hubToken))
 	rootCmd.AddCommand(newListCommand(&serverURL, &hubToken))
+	rootCmd.AddCommand(newSearchCommand())
+	rootCmd.AddCommand(newPublishCommand())
 	return rootCmd
 }
 
@@ -71,26 +75,32 @@ func newAddCommand(serverURL, hubToken *string) *cobra.Command {
 	var clipToken string
 	var name string
 	var provider string
+	var registryURL string
 	cmd := &cobra.Command{
 		Use:   "add <source>",
 		Short: "Install and register a Clip",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			source, err := normalizeAddSource(args[0], registryURL)
+			if err != nil {
+				return err
+			}
 			cli, err := client.New(*serverURL)
 			if err != nil {
 				return err
 			}
-			clip, err := cli.Add(cmd.Context(), args[0], name, provider, clipToken, *hubToken)
+			clip, err := cli.Add(cmd.Context(), source, name, provider, clipToken, *hubToken)
 			if err != nil {
 				return err
 			}
-			fmt.Printf("%s\t%s\t%s\n", clip.GetName(), clip.GetProvider(), firstNonEmpty(clip.GetPackage(), "-"))
+			fmt.Printf("%s\t%s\t%s\t%s\n", clip.GetName(), firstNonEmpty(clip.GetPackage(), "-"), firstNonEmpty(clip.GetVersion(), "-"), clip.GetProvider())
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&clipToken, "token", "", "clip token required for invoking this Clip")
 	cmd.Flags().StringVar(&name, "name", "", "explicit clip instance name")
 	cmd.Flags().StringVar(&provider, "provider", "", "target provider for add/remove operations")
+	cmd.Flags().StringVar(&registryURL, "registry", os.Getenv("PINIX_REGISTRY"), "install Clip from a Pinix Registry instead of npm")
 	return cmd
 }
 
@@ -134,7 +144,7 @@ func newListCommand(serverURL, hubToken *string) *cobra.Command {
 			}
 			for _, clip := range clips {
 				commands := strings.Join(clipCommandNames(clip), ",")
-				fmt.Printf("%s\t%s\t%s\t%s\n", clip.GetName(), clip.GetProvider(), firstNonEmpty(clip.GetPackage(), "-"), commands)
+				fmt.Printf("%s\t%s\t%s\t%s\t%s\n", clip.GetName(), firstNonEmpty(clip.GetPackage(), "-"), firstNonEmpty(clip.GetVersion(), "-"), clip.GetProvider(), commands)
 			}
 			return nil
 		},

--- a/cmd/pinix/registry.go
+++ b/cmd/pinix/registry.go
@@ -1,0 +1,710 @@
+// Role:    Registry source translation plus search/publish helpers for the pinix CLI
+// Depends: archive/tar, bytes, compress/gzip, context, encoding/json, errors, fmt, io, io/fs, os, path/filepath, strings, internal/client, internal/daemon, cobra
+// Exports: (package-internal helpers)
+
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/epiral/pinix/internal/client"
+	daemonpkg "github.com/epiral/pinix/internal/daemon"
+	"github.com/spf13/cobra"
+)
+
+type registryPublishManifest struct {
+	Name         string            `json:"name"`
+	Version      string            `json:"version"`
+	Type         string            `json:"type"`
+	Description  string            `json:"description"`
+	Domain       string            `json:"domain,omitempty"`
+	Runtime      string            `json:"runtime,omitempty"`
+	Main         string            `json:"main,omitempty"`
+	Web          string            `json:"web,omitempty"`
+	Commands     []map[string]any  `json:"commands,omitempty"`
+	Dependencies map[string]string `json:"dependencies,omitempty"`
+	Patterns     []string          `json:"patterns,omitempty"`
+}
+
+type localPackageJSON struct {
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	Description string `json:"description,omitempty"`
+	Main        string `json:"main,omitempty"`
+	Bin         any    `json:"bin,omitempty"`
+}
+
+func newSearchCommand() *cobra.Command {
+	var registryURL string
+	var domain string
+	var packageType string
+
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Search Clips in a Pinix Registry",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(registryURL) == "" {
+				return fmt.Errorf("--registry is required")
+			}
+			reg, err := client.NewRegistry(registryURL)
+			if err != nil {
+				return err
+			}
+			resp, err := reg.Search(cmd.Context(), args[0], domain, packageType)
+			if err != nil {
+				return err
+			}
+			if resp == nil || len(resp.Results) == 0 {
+				fmt.Println("(no results)")
+				return nil
+			}
+			for _, item := range resp.Results {
+				fmt.Printf("%s\t%s\t%s\t%s\n", item.Name, firstNonEmpty(item.Version, "-"), firstNonEmpty(item.Type, "-"), firstNonEmpty(item.Description, "-"))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&registryURL, "registry", os.Getenv("PINIX_REGISTRY"), "Pinix Registry base URL")
+	cmd.Flags().StringVar(&domain, "domain", "", "filter results by domain")
+	cmd.Flags().StringVar(&packageType, "type", "", "filter results by package type")
+	return cmd
+}
+
+func newPublishCommand() *cobra.Command {
+	var registryURL string
+	var registryToken string
+	var tag string
+
+	cmd := &cobra.Command{
+		Use:   "publish [path]",
+		Short: "Publish a local Clip package to a Pinix Registry",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(registryURL) == "" {
+				return fmt.Errorf("--registry is required")
+			}
+			dir := "."
+			if len(args) == 1 {
+				dir = args[0]
+			}
+
+			manifestRaw, manifest, err := loadRegistryPublishManifest(dir)
+			if err != nil {
+				return err
+			}
+			tarball, err := buildRegistryTarball(dir, manifestRaw)
+			if err != nil {
+				return err
+			}
+			if strings.EqualFold(strings.TrimSpace(manifest.Type), "edge-clip") {
+				tarball = nil
+			}
+
+			reg, err := client.NewRegistry(registryURL)
+			if err != nil {
+				return err
+			}
+			resp, err := reg.Publish(cmd.Context(), manifest.Name, registryToken, manifestRaw, tarball, tag)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("%s\t%s\t%s\n", resp.Name, resp.Version, firstNonEmpty(resp.Tag, tag, "latest"))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&registryURL, "registry", os.Getenv("PINIX_REGISTRY"), "Pinix Registry base URL")
+	cmd.Flags().StringVar(&registryToken, "registry-token", os.Getenv("PINIX_REGISTRY_TOKEN"), "registry auth token")
+	cmd.Flags().StringVar(&tag, "tag", "", "dist-tag to publish under")
+	return cmd
+}
+
+func normalizeAddSource(source, registryURL string) (string, error) {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return "", fmt.Errorf("source is required")
+	}
+	if strings.HasPrefix(source, "npm:") || strings.HasPrefix(source, "registry:") || strings.HasPrefix(source, "github:") {
+		return source, nil
+	}
+	if looksLikeScopedPackage(source) {
+		pkg, version := splitPackageVersionSpec(source)
+		if strings.TrimSpace(registryURL) == "" {
+			return canonicalNPMSource(pkg, version), nil
+		}
+		reg, err := client.NewRegistry(registryURL)
+		if err != nil {
+			return "", err
+		}
+		return canonicalRegistrySource(reg.BaseURL(), pkg, version), nil
+	}
+	if looksLikeLocalPath(source) {
+		return source, nil
+	}
+
+	pkg, version := splitPackageVersionSpec(source)
+	if pkg == "" {
+		return "", fmt.Errorf("invalid source %q", source)
+	}
+	if strings.TrimSpace(registryURL) == "" {
+		return canonicalNPMSource(pkg, version), nil
+	}
+	reg, err := client.NewRegistry(registryURL)
+	if err != nil {
+		return "", err
+	}
+	return canonicalRegistrySource(reg.BaseURL(), pkg, version), nil
+}
+
+func splitPackageVersionSpec(spec string) (string, string) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return "", ""
+	}
+
+	versionIndex := -1
+	if strings.HasPrefix(spec, "@") {
+		slash := strings.Index(spec, "/")
+		if slash <= 1 || slash == len(spec)-1 {
+			return "", ""
+		}
+		if at := strings.LastIndex(spec, "@"); at > slash {
+			versionIndex = at
+		} else if colon := strings.LastIndex(spec, ":"); colon > slash {
+			versionIndex = colon
+		}
+	} else {
+		if at := strings.LastIndex(spec, "@"); at > 0 {
+			versionIndex = at
+		} else if colon := strings.LastIndex(spec, ":"); colon > 0 {
+			versionIndex = colon
+		}
+	}
+
+	if versionIndex <= 0 {
+		return spec, ""
+	}
+	return strings.TrimSpace(spec[:versionIndex]), strings.TrimSpace(spec[versionIndex+1:])
+}
+
+func looksLikeScopedPackage(spec string) bool {
+	pkg, _ := splitPackageVersionSpec(spec)
+	if !strings.HasPrefix(pkg, "@") {
+		return false
+	}
+	parts := strings.Split(pkg, "/")
+	return len(parts) == 2 && strings.TrimSpace(parts[0]) != "" && strings.TrimSpace(parts[1]) != ""
+}
+
+func looksLikeLocalPath(spec string) bool {
+	if spec == "" {
+		return false
+	}
+	if strings.Contains(spec, "://") {
+		return false
+	}
+	if strings.HasPrefix(spec, "@") && looksLikeScopedPackage(spec) {
+		return false
+	}
+	return strings.Contains(spec, "/") || strings.HasPrefix(spec, ".") || strings.HasPrefix(spec, "~")
+}
+
+func canonicalNPMSource(pkg, version string) string {
+	pkg = strings.TrimSpace(pkg)
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return "npm:" + pkg
+	}
+	return "npm:" + pkg + "@" + version
+}
+
+func canonicalRegistrySource(registryURL, pkg, version string) string {
+	registryURL = strings.TrimRight(strings.TrimSpace(registryURL), "/")
+	pkg = strings.TrimSpace(pkg)
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return "registry:" + registryURL + "#" + pkg
+	}
+	return "registry:" + registryURL + "#" + pkg + "@" + version
+}
+
+func loadRegistryPublishManifest(dir string) (json.RawMessage, *registryPublishManifest, error) {
+	absDir, err := filepath.Abs(strings.TrimSpace(dir))
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve publish path: %w", err)
+	}
+
+	synthesized, synthErr := synthesizeRegistryPublishManifest(absDir)
+	manifest := synthesized
+
+	pinixPath := filepath.Join(absDir, "pinix.json")
+	if data, err := os.ReadFile(pinixPath); err == nil {
+		var existing registryPublishManifest
+		if err := json.Unmarshal(data, &existing); err != nil {
+			return nil, nil, fmt.Errorf("parse %s: %w", pinixPath, err)
+		}
+		if manifest == nil {
+			manifest = &registryPublishManifest{}
+		}
+		mergeRegistryPublishManifest(manifest, &existing)
+	} else if !os.IsNotExist(err) {
+		return nil, nil, fmt.Errorf("read %s: %w", pinixPath, err)
+	}
+
+	if manifest == nil {
+		if synthErr != nil {
+			return nil, nil, synthErr
+		}
+		return nil, nil, fmt.Errorf("manifest is required")
+	}
+	if err := finalizeRegistryPublishManifest(manifest, absDir); err != nil {
+		if synthErr != nil {
+			return nil, nil, errors.Join(err, synthErr)
+		}
+		return nil, nil, err
+	}
+
+	raw, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal manifest: %w", err)
+	}
+	raw = append(raw, '\n')
+	return json.RawMessage(raw), manifest, nil
+}
+
+func synthesizeRegistryPublishManifest(dir string) (*registryPublishManifest, error) {
+	pkg, pkgErr := readLocalPackageJSON(dir)
+	inspected, inspectErr := inspectLocalClip(dir, pkg)
+
+	manifest := &registryPublishManifest{
+		Name:         deriveRegistryPackageName(pkg, inspected, dir),
+		Version:      firstNonEmpty(pkg.Version, manifestVersionValue(inspected)),
+		Type:         "clip",
+		Description:  firstNonEmpty(manifestDescriptionValue(inspected), pkg.Description),
+		Domain:       manifestDomainValue(inspected),
+		Runtime:      "bun",
+		Main:         firstNonEmpty(strings.TrimSpace(pkg.Main), packageJSONBin(pkg), defaultMainEntry(dir)),
+		Web:          defaultWebEntry(dir),
+		Commands:     commandMapsFromManifest(inspected),
+		Dependencies: dependencyMap(manifestDependenciesValue(inspected)),
+		Patterns:     manifestPatternsValue(inspected),
+	}
+
+	if pkgErr == nil && strings.TrimSpace(pkg.Name) != "" && strings.TrimSpace(manifest.Version) != "" {
+		return manifest, inspectErr
+	}
+	if inspectErr != nil {
+		if pkgErr != nil {
+			return manifest, errors.Join(pkgErr, inspectErr)
+		}
+		return manifest, inspectErr
+	}
+	return manifest, pkgErr
+}
+
+func finalizeRegistryPublishManifest(manifest *registryPublishManifest, dir string) error {
+	if manifest == nil {
+		return fmt.Errorf("manifest is required")
+	}
+	manifest.Name = strings.TrimSpace(manifest.Name)
+	manifest.Version = strings.TrimSpace(manifest.Version)
+	manifest.Type = firstNonEmpty(strings.TrimSpace(manifest.Type), "clip")
+	manifest.Description = strings.TrimSpace(manifest.Description)
+	manifest.Domain = strings.TrimSpace(manifest.Domain)
+	manifest.Runtime = firstNonEmpty(strings.TrimSpace(manifest.Runtime), "bun")
+	manifest.Main = firstNonEmpty(strings.TrimSpace(manifest.Main), defaultMainEntry(dir))
+	manifest.Web = strings.TrimSpace(manifest.Web)
+	manifest.Patterns = normalizeStrings(manifest.Patterns)
+
+	if manifest.Name == "" {
+		return fmt.Errorf("manifest.name is required")
+	}
+	if manifest.Version == "" {
+		return fmt.Errorf("manifest.version is required")
+	}
+	if manifest.Description == "" {
+		return fmt.Errorf("manifest.description is required")
+	}
+	if len(manifest.Commands) == 0 {
+		return fmt.Errorf("manifest.commands is required")
+	}
+	if len(manifest.Dependencies) == 0 {
+		manifest.Dependencies = nil
+	}
+	if len(manifest.Patterns) == 0 {
+		manifest.Patterns = nil
+	}
+	if manifest.Web == "" {
+		manifest.Web = defaultWebEntry(dir)
+	}
+	return nil
+}
+
+func mergeRegistryPublishManifest(base, override *registryPublishManifest) {
+	if base == nil || override == nil {
+		return
+	}
+	base.Name = firstNonEmpty(override.Name, base.Name)
+	base.Version = firstNonEmpty(override.Version, base.Version)
+	base.Type = firstNonEmpty(override.Type, base.Type)
+	base.Description = firstNonEmpty(override.Description, base.Description)
+	base.Domain = firstNonEmpty(override.Domain, base.Domain)
+	base.Runtime = firstNonEmpty(override.Runtime, base.Runtime)
+	base.Main = firstNonEmpty(override.Main, base.Main)
+	base.Web = firstNonEmpty(override.Web, base.Web)
+	if len(override.Commands) > 0 {
+		base.Commands = override.Commands
+	}
+	if len(override.Dependencies) > 0 {
+		base.Dependencies = override.Dependencies
+	}
+	if len(override.Patterns) > 0 {
+		base.Patterns = override.Patterns
+	}
+}
+
+func readLocalPackageJSON(dir string) (localPackageJSON, error) {
+	data, err := os.ReadFile(filepath.Join(dir, "package.json"))
+	if err != nil {
+		return localPackageJSON{}, fmt.Errorf("read package.json: %w", err)
+	}
+	var pkg localPackageJSON
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return localPackageJSON{}, fmt.Errorf("parse package.json: %w", err)
+	}
+	return pkg, nil
+}
+
+func inspectLocalClip(dir string, pkg localPackageJSON) (*daemonpkg.ManifestCache, error) {
+	manifest, err := daemonpkg.InspectClipManifest(context.Background(), daemonpkg.ClipConfig{
+		Name:    firstNonEmpty(filepath.Base(dir), "clip"),
+		Package: strings.TrimSpace(pkg.Name),
+		Version: strings.TrimSpace(pkg.Version),
+		Source:  dir,
+		Path:    dir,
+	}, "", "", nil, nil, "")
+	if err != nil {
+		return nil, fmt.Errorf("inspect local clip: %w", err)
+	}
+	return manifest, nil
+}
+
+func deriveRegistryPackageName(pkg localPackageJSON, manifest *daemonpkg.ManifestCache, dir string) string {
+	if manifest != nil && strings.TrimSpace(manifest.Name) != "" {
+		return strings.TrimSpace(manifest.Name)
+	}
+	if strings.TrimSpace(pkg.Name) != "" {
+		return defaultPackageName(pkg.Name)
+	}
+	return defaultPackageName(filepath.Base(dir))
+}
+
+func defaultPackageName(value string) string {
+	value = filepath.Base(filepath.FromSlash(strings.TrimSpace(value)))
+	value = strings.TrimPrefix(value, "clip-")
+	value = strings.TrimPrefix(value, "@")
+	return strings.TrimSpace(value)
+}
+
+func packageJSONBin(pkg localPackageJSON) string {
+	switch value := pkg.Bin.(type) {
+	case string:
+		return strings.TrimSpace(value)
+	case map[string]any:
+		for _, item := range value {
+			if path, ok := item.(string); ok && strings.TrimSpace(path) != "" {
+				return strings.TrimSpace(path)
+			}
+		}
+	case map[string]string:
+		for _, item := range value {
+			if strings.TrimSpace(item) != "" {
+				return strings.TrimSpace(item)
+			}
+		}
+	}
+	return ""
+}
+
+func defaultMainEntry(dir string) string {
+	if isRegularFile(filepath.Join(dir, "index.ts")) {
+		return "index.ts"
+	}
+	return ""
+}
+
+func defaultWebEntry(dir string) string {
+	if dirExists(filepath.Join(dir, "web")) {
+		return "web"
+	}
+	return ""
+}
+
+func commandMapsFromManifest(manifest *daemonpkg.ManifestCache) []map[string]any {
+	if manifest == nil {
+		return nil
+	}
+	result := make([]map[string]any, 0, len(manifest.CommandDetails))
+	for _, command := range manifest.CommandDetails {
+		name := strings.TrimSpace(command.Name)
+		if name == "" {
+			continue
+		}
+		item := map[string]any{"name": name}
+		if description := strings.TrimSpace(command.Description); description != "" {
+			item["description"] = description
+		}
+		if input := maybeJSONValue(command.Input); input != nil {
+			item["input"] = input
+		}
+		if output := maybeJSONValue(command.Output); output != nil {
+			item["output"] = output
+		}
+		result = append(result, item)
+	}
+	if len(result) == 0 && len(manifest.Commands) > 0 {
+		for _, name := range manifest.Commands {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			result = append(result, map[string]any{"name": name})
+		}
+	}
+	return result
+}
+
+func maybeJSONValue(raw string) any {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	if json.Valid([]byte(raw)) {
+		var value any
+		if err := json.Unmarshal([]byte(raw), &value); err == nil {
+			return value
+		}
+	}
+	return raw
+}
+
+func dependencyMap(dependencies []string) map[string]string {
+	if len(dependencies) == 0 {
+		return nil
+	}
+	result := make(map[string]string, len(dependencies))
+	for _, dependency := range dependencies {
+		dependency = strings.TrimSpace(dependency)
+		if dependency == "" {
+			continue
+		}
+		result[dependency] = "*"
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+func buildRegistryTarball(dir string, manifestRaw json.RawMessage) ([]byte, error) {
+	absDir, err := filepath.Abs(strings.TrimSpace(dir))
+	if err != nil {
+		return nil, fmt.Errorf("resolve package path: %w", err)
+	}
+
+	var buffer bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buffer)
+	tarWriter := tar.NewWriter(gzipWriter)
+
+	err = filepath.WalkDir(absDir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(absDir, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		if shouldSkipTarPath(rel, entry) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		return addTarEntry(tarWriter, absDir, rel, path, entry)
+	})
+	if err != nil {
+		tarWriter.Close()
+		gzipWriter.Close()
+		return nil, fmt.Errorf("pack registry tarball: %w", err)
+	}
+	if err := addTarOverlay(tarWriter, "package/pinix.json", manifestRaw, 0o644); err != nil {
+		tarWriter.Close()
+		gzipWriter.Close()
+		return nil, err
+	}
+	if err := tarWriter.Close(); err != nil {
+		gzipWriter.Close()
+		return nil, fmt.Errorf("close tar writer: %w", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		return nil, fmt.Errorf("close gzip writer: %w", err)
+	}
+	return buffer.Bytes(), nil
+}
+
+func shouldSkipTarPath(rel string, entry fs.DirEntry) bool {
+	rel = filepath.Clean(rel)
+	if rel == "." || rel == "" {
+		return false
+	}
+	top := strings.Split(rel, string(os.PathSeparator))[0]
+	if top == ".git" || top == "node_modules" {
+		return true
+	}
+	return filepath.Base(rel) == "pinix.json"
+}
+
+func addTarEntry(writer *tar.Writer, rootDir, rel, path string, entry fs.DirEntry) error {
+	info, err := entry.Info()
+	if err != nil {
+		return err
+	}
+	name := filepath.ToSlash(filepath.Join("package", rel))
+	if entry.IsDir() {
+		header, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		header.Name = strings.TrimSuffix(name, "/") + "/"
+		return writer.WriteHeader(header)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		linkTarget, err := os.Readlink(path)
+		if err != nil {
+			return err
+		}
+		header, err := tar.FileInfoHeader(info, linkTarget)
+		if err != nil {
+			return err
+		}
+		header.Name = name
+		return writer.WriteHeader(header)
+	}
+	if !info.Mode().IsRegular() {
+		return nil
+	}
+
+	header, err := tar.FileInfoHeader(info, "")
+	if err != nil {
+		return err
+	}
+	header.Name = name
+	if err := writer.WriteHeader(header); err != nil {
+		return err
+	}
+	file, err := os.Open(filepath.Join(rootDir, rel))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	_, err = io.Copy(writer, file)
+	return err
+}
+
+func addTarOverlay(writer *tar.Writer, name string, data []byte, mode int64) error {
+	header := &tar.Header{
+		Name:     strings.TrimSpace(name),
+		Mode:     mode,
+		Size:     int64(len(data)),
+		Typeflag: tar.TypeReg,
+	}
+	if err := writer.WriteHeader(header); err != nil {
+		return fmt.Errorf("write tar overlay header: %w", err)
+	}
+	if _, err := writer.Write(data); err != nil {
+		return fmt.Errorf("write tar overlay body: %w", err)
+	}
+	return nil
+}
+
+func manifestVersionValue(manifest *daemonpkg.ManifestCache) string {
+	if manifest == nil {
+		return ""
+	}
+	return strings.TrimSpace(manifest.Version)
+}
+
+func manifestDescriptionValue(manifest *daemonpkg.ManifestCache) string {
+	if manifest == nil {
+		return ""
+	}
+	return strings.TrimSpace(manifest.Description)
+}
+
+func manifestDomainValue(manifest *daemonpkg.ManifestCache) string {
+	if manifest == nil {
+		return ""
+	}
+	return strings.TrimSpace(manifest.Domain)
+}
+
+func manifestDependenciesValue(manifest *daemonpkg.ManifestCache) []string {
+	if manifest == nil {
+		return nil
+	}
+	return append([]string(nil), manifest.Dependencies...)
+}
+
+func manifestPatternsValue(manifest *daemonpkg.ManifestCache) []string {
+	if manifest == nil {
+		return nil
+	}
+	return append([]string(nil), manifest.Patterns...)
+}
+
+func normalizeStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}
+
+func isRegularFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.Mode().IsRegular()
+}

--- a/internal/client/registry.go
+++ b/internal/client/registry.go
@@ -1,0 +1,325 @@
+// Role:    HTTP client for Pinix Registry package, search, auth, and publish APIs
+// Depends: bytes, context, encoding/json, fmt, io, mime/multipart, net/http, net/url, strings
+// Exports: RegistryClient, NewRegistry, RegistryPackageDocument, RegistryVersionDocument, RegistryDistInfo, RegistrySearchResponse, RegistrySearchResult, RegistryPublishResponse, RegistryAuthResponse
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type RegistryClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+type RegistryDistInfo struct {
+	Tarball string `json:"tarball,omitempty"`
+	Shasum  string `json:"shasum,omitempty"`
+	Size    int64  `json:"size,omitempty"`
+}
+
+type RegistryVersionDocument struct {
+	Pinix      json.RawMessage   `json:"pinix"`
+	Dist       *RegistryDistInfo `json:"dist,omitempty"`
+	Deprecated string            `json:"deprecated,omitempty"`
+}
+
+type RegistryPackageDocument struct {
+	Name        string                             `json:"name"`
+	Type        string                             `json:"type"`
+	Description string                             `json:"description"`
+	Domain      string                             `json:"domain,omitempty"`
+	DistTags    map[string]string                  `json:"dist-tags"`
+	Versions    map[string]RegistryVersionDocument `json:"versions"`
+}
+
+type RegistrySearchResponse struct {
+	Results []RegistrySearchResult `json:"results"`
+	Total   int                    `json:"total"`
+}
+
+type RegistrySearchResult struct {
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	Description string `json:"description"`
+	Type        string `json:"type"`
+	Domain      string `json:"domain,omitempty"`
+}
+
+type RegistryPublishResponse struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Tag     string `json:"tag"`
+}
+
+type RegistryAuthResponse struct {
+	Token    string `json:"token,omitempty"`
+	Username string `json:"username,omitempty"`
+}
+
+type registryAPIError struct {
+	Error string `json:"error"`
+}
+
+func NewRegistry(baseURL string) (*RegistryClient, error) {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		return nil, fmt.Errorf("registry URL is required")
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse registry URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("registry URL must use http or https")
+	}
+	if parsed.Host == "" {
+		return nil, fmt.Errorf("registry URL host is required")
+	}
+	return &RegistryClient{baseURL: baseURL, httpClient: http.DefaultClient}, nil
+}
+
+func (c *RegistryClient) BaseURL() string {
+	if c == nil {
+		return ""
+	}
+	return c.baseURL
+}
+
+func (c *RegistryClient) GetPackage(ctx context.Context, name string) (*RegistryPackageDocument, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("package name is required")
+	}
+	var doc RegistryPackageDocument
+	if err := c.getJSON(ctx, "/packages/"+url.PathEscape(name), &doc); err != nil {
+		return nil, err
+	}
+	if doc.DistTags == nil {
+		doc.DistTags = make(map[string]string)
+	}
+	if doc.Versions == nil {
+		doc.Versions = make(map[string]RegistryVersionDocument)
+	}
+	return &doc, nil
+}
+
+func (d *RegistryPackageDocument) ResolveVersion(requested string) (string, *RegistryVersionDocument, error) {
+	if d == nil {
+		return "", nil, fmt.Errorf("registry package document is required")
+	}
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		requested = strings.TrimSpace(d.DistTags["latest"])
+	}
+	if requested == "" {
+		return "", nil, fmt.Errorf("package %q does not have a latest dist-tag", d.Name)
+	}
+	if version, ok := d.DistTags[requested]; ok {
+		requested = strings.TrimSpace(version)
+	}
+	versionDoc, ok := d.Versions[requested]
+	if !ok {
+		return "", nil, fmt.Errorf("package %q version or dist-tag %q not found", d.Name, requested)
+	}
+	copy := versionDoc
+	return requested, &copy, nil
+}
+
+func (c *RegistryClient) Search(ctx context.Context, query, domain, packageType string) (*RegistrySearchResponse, error) {
+	values := url.Values{}
+	values.Set("q", strings.TrimSpace(query))
+	if strings.TrimSpace(domain) != "" {
+		values.Set("domain", strings.TrimSpace(domain))
+	}
+	if strings.TrimSpace(packageType) != "" {
+		values.Set("type", strings.TrimSpace(packageType))
+	}
+	var resp RegistrySearchResponse
+	if err := c.getJSON(ctx, "/search?"+values.Encode(), &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *RegistryClient) Download(ctx context.Context, rawURL string) ([]byte, error) {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return nil, fmt.Errorf("tarball URL is required")
+	}
+	resolved := rawURL
+	if parsed, err := url.Parse(rawURL); err == nil && !parsed.IsAbs() {
+		base, baseErr := url.Parse(c.baseURL + "/")
+		if baseErr == nil {
+			resolved = base.ResolveReference(parsed).String()
+		}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, resolved, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build registry download request: %w", err)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download registry tarball: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, c.decodeAPIError(resp, "download registry tarball")
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read registry tarball: %w", err)
+	}
+	return data, nil
+}
+
+func (c *RegistryClient) Publish(ctx context.Context, name, token string, manifest json.RawMessage, tarball []byte, tag string) (*RegistryPublishResponse, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("package name is required")
+	}
+	if strings.TrimSpace(token) == "" {
+		return nil, fmt.Errorf("registry token is required")
+	}
+	if len(bytes.TrimSpace(manifest)) == 0 {
+		return nil, fmt.Errorf("manifest is required")
+	}
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	if err := writer.WriteField("manifest", strings.TrimSpace(string(manifest))); err != nil {
+		return nil, fmt.Errorf("write registry manifest field: %w", err)
+	}
+	if strings.TrimSpace(tag) != "" {
+		if err := writer.WriteField("tag", strings.TrimSpace(tag)); err != nil {
+			return nil, fmt.Errorf("write registry tag field: %w", err)
+		}
+	}
+	if len(tarball) > 0 {
+		fileName := name + ".tgz"
+		part, err := writer.CreateFormFile("tarball", fileName)
+		if err != nil {
+			return nil, fmt.Errorf("create registry tarball field: %w", err)
+		}
+		if _, err := part.Write(tarball); err != nil {
+			return nil, fmt.Errorf("write registry tarball field: %w", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("close registry multipart body: %w", err)
+	}
+
+	var resp RegistryPublishResponse
+	if err := c.doJSON(ctx, http.MethodPut, "/packages/"+url.PathEscape(name), body, writer.FormDataContentType(), token, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *RegistryClient) Register(ctx context.Context, username, email, password string) (*RegistryAuthResponse, error) {
+	payload := map[string]string{
+		"username": strings.TrimSpace(username),
+		"email":    strings.TrimSpace(email),
+		"password": password,
+	}
+	var resp RegistryAuthResponse
+	if err := c.postJSON(ctx, "/auth/register", payload, "", &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *RegistryClient) Login(ctx context.Context, username, password string) (*RegistryAuthResponse, error) {
+	payload := map[string]string{
+		"username": strings.TrimSpace(username),
+		"password": password,
+	}
+	var resp RegistryAuthResponse
+	if err := c.postJSON(ctx, "/auth/login", payload, "", &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *RegistryClient) WhoAmI(ctx context.Context, token string) (*RegistryAuthResponse, error) {
+	var resp RegistryAuthResponse
+	if err := c.doJSON(ctx, http.MethodGet, "/auth/whoami", nil, "application/json", token, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *RegistryClient) getJSON(ctx context.Context, path string, out any) error {
+	return c.doJSON(ctx, http.MethodGet, path, nil, "application/json", "", out)
+}
+
+func (c *RegistryClient) postJSON(ctx context.Context, path string, payload any, token string, out any) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal registry request body: %w", err)
+	}
+	return c.doJSON(ctx, http.MethodPost, path, bytes.NewReader(data), "application/json", token, out)
+}
+
+func (c *RegistryClient) doJSON(ctx context.Context, method, path string, body io.Reader, contentType, token string, out any) error {
+	if c == nil {
+		return fmt.Errorf("registry client is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if strings.TrimSpace(contentType) == "" {
+		contentType = "application/json"
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
+	if err != nil {
+		return fmt.Errorf("build registry request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", contentType)
+	}
+	req.Header.Set("Accept", "application/json")
+	if strings.TrimSpace(token) != "" {
+		req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(token))
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("registry %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return c.decodeAPIError(resp, fmt.Sprintf("registry %s %s", method, path))
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("decode registry response: %w", err)
+	}
+	return nil
+}
+
+func (c *RegistryClient) decodeAPIError(resp *http.Response, action string) error {
+	if resp == nil {
+		return fmt.Errorf("%s: empty response", action)
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	message := strings.TrimSpace(string(body))
+	var apiErr registryAPIError
+	if err := json.Unmarshal(body, &apiErr); err == nil && strings.TrimSpace(apiErr.Error) != "" {
+		message = strings.TrimSpace(apiErr.Error)
+	}
+	if message == "" {
+		message = http.StatusText(resp.StatusCode)
+	}
+	return fmt.Errorf("%s: %s", action, message)
+}

--- a/internal/daemon/clipweb.go
+++ b/internal/daemon/clipweb.go
@@ -34,8 +34,8 @@ type clipWebRangeRequest struct {
 	Partial bool
 }
 
-func readClipWebFile(workdir, requestedPath string, opts clipWebReadOptions) (*clipWebReadResult, error) {
-	webRoot := filepath.Clean(filepath.Join(workdir, "web"))
+func readClipWebFile(webRoot, requestedPath string, opts clipWebReadOptions) (*clipWebReadResult, error) {
+	webRoot = filepath.Clean(strings.TrimSpace(webRoot))
 	requestedPath = filepath.Clean(strings.TrimPrefix(strings.TrimSpace(requestedPath), "/"))
 	if requestedPath == "." {
 		requestedPath = ""

--- a/internal/daemon/connect.go
+++ b/internal/daemon/connect.go
@@ -351,7 +351,7 @@ func (h *HubService) readLocalClipWebFile(clipName, requestedPath string, opts c
 	if !found {
 		return nil, daemonError{Code: "not_found", Message: fmt.Sprintf("clip %q not found", clipName)}
 	}
-	return readClipWebFile(clip.Path, requestedPath, opts)
+	return readClipWebFile(clipWebDir(clip), requestedPath, opts)
 }
 
 func (h *HubService) readProviderClipWebFile(ctx context.Context, clipName, requestedPath string, opts clipWebReadOptions) (*clipWebReadResult, error) {

--- a/internal/daemon/handler.go
+++ b/internal/daemon/handler.go
@@ -1,5 +1,5 @@
 // Role:    Shared add/remove/install helpers for the Pinix daemon HubService
-// Depends: context, fmt, os, os/exec, path/filepath, strings
+// Depends: context, fmt, os, path/filepath, strings
 // Exports: Handler, NewHandler
 
 package daemon
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -57,17 +56,21 @@ func (h *Handler) handleAddTrusted(ctx context.Context, params AddParams) (*AddR
 }
 
 func (h *Handler) addClip(ctx context.Context, params AddParams) (*AddResult, error) {
-	sourceType, normalizedSource, err := classifySource(params.Source)
+	if h == nil || h.registry == nil || h.process == nil {
+		return nil, daemonError{Code: "internal", Message: "handler is not configured"}
+	}
+
+	ref, err := parseSource(params.Source)
 	if err != nil {
 		return nil, err
 	}
 
-	stagingName := deriveNameFromSource(normalizedSource)
+	stagingName := deriveNameFromSource(ref.Source)
 	if explicitName := normalizeName(params.Name); explicitName != "" {
 		stagingName = explicitName
 	}
 	if stagingName == "" {
-		return nil, daemonError{Code: "invalid_argument", Message: fmt.Sprintf("could not derive clip name from %q", normalizedSource)}
+		return nil, daemonError{Code: "invalid_argument", Message: fmt.Sprintf("could not derive clip name from %q", ref.Source)}
 	}
 
 	stagePath := filepath.Join(h.registry.ClipsDir(), ".staging-"+stagingName)
@@ -80,42 +83,23 @@ func (h *Handler) addClip(ctx context.Context, params AddParams) (*AddResult, er
 		_ = os.RemoveAll(stagePath)
 	}
 
-	var clipPath string
-	switch sourceType {
-	case sourceTypeNPM:
-		if err := installFromNPM(stagePath, normalizedSource, h.process.BunPath()); err != nil {
-			cleanup()
-			return nil, daemonError{Code: "internal", Message: err.Error()}
-		}
-		clipPath = stagePath
-	case sourceTypeGitHub:
-		if err := installFromGitHub(stagePath, normalizedSource, h.process.BunPath()); err != nil {
-			cleanup()
-			return nil, daemonError{Code: "internal", Message: err.Error()}
-		}
-		clipPath = stagePath
-	case sourceTypeLocal:
-		resolvedPath, err := filepath.Abs(normalizedSource)
-		if err != nil {
-			return nil, daemonError{Code: "invalid_argument", Message: fmt.Sprintf("resolve local path: %v", err)}
-		}
-		info, err := os.Stat(resolvedPath)
-		if err != nil {
-			return nil, daemonError{Code: "not_found", Message: fmt.Sprintf("local clip path %s not found", resolvedPath)}
-		}
-		if !info.IsDir() {
-			return nil, daemonError{Code: "invalid_argument", Message: fmt.Sprintf("local clip path %s is not a directory", resolvedPath)}
-		}
-		clipPath = resolvedPath
-	default:
-		return nil, daemonError{Code: "invalid_argument", Message: fmt.Sprintf("unsupported source %q", normalizedSource)}
-	}
-
-	manifest, err := h.inspectClip(ctx, ClipConfig{Name: stagingName, Source: normalizedSource, Path: clipPath, Token: params.Token})
+	installedRef, clipPath, err := h.installClip(ctx, ref, stagePath)
 	if err != nil {
-		if sourceType != sourceTypeLocal {
-			cleanup()
-		}
+		cleanup()
+		return nil, err
+	}
+	ref = installedRef
+
+	manifest, err := h.inspectClip(ctx, ClipConfig{
+		Name:    stagingName,
+		Package: strings.TrimSpace(ref.Package),
+		Version: strings.TrimSpace(ref.Version),
+		Source:  ref.Source,
+		Path:    clipPath,
+		Token:   params.Token,
+	})
+	if err != nil {
+		cleanup()
 		return nil, daemonError{Code: "internal", Message: fmt.Sprintf("load clip manifest: %v", err)}
 	}
 
@@ -126,54 +110,43 @@ func (h *Handler) addClip(ctx context.Context, params AddParams) (*AddResult, er
 		finalName = normalizeName(manifest.Name)
 	}
 	if finalName == "" {
-		if sourceType != sourceTypeLocal {
-			cleanup()
-		}
+		cleanup()
 		return nil, daemonError{Code: "invalid_argument", Message: "clip manifest did not provide a usable name"}
 	}
 
 	if _, exists, err := h.registry.GetClip(finalName); err != nil {
-		if sourceType != sourceTypeLocal {
-			cleanup()
-		}
+		cleanup()
 		return nil, daemonError{Code: "internal", Message: fmt.Sprintf("check existing clip: %v", err)}
 	} else if exists {
-		if sourceType != sourceTypeLocal {
-			cleanup()
-		}
+		cleanup()
 		return nil, daemonError{Code: "already_exists", Message: fmt.Sprintf("clip %q already exists", finalName)}
 	}
 
-	finalPath := clipPath
-	if sourceType == sourceTypeLocal {
-		finalPath = filepath.Join(h.registry.ClipsDir(), finalName)
-		if err := os.Symlink(clipPath, finalPath); err != nil {
-			if os.IsExist(err) {
-				return nil, daemonError{Code: "already_exists", Message: fmt.Sprintf("clip path %s already exists", finalPath)}
-			}
-			return nil, daemonError{Code: "internal", Message: fmt.Sprintf("create clip symlink: %v", err)}
-		}
-		cleanup = func() { _ = os.Remove(finalPath) }
-	} else if stagePath != filepath.Join(h.registry.ClipsDir(), finalName) {
-		finalPath = filepath.Join(h.registry.ClipsDir(), finalName)
-		_ = os.RemoveAll(finalPath)
-		if err := os.Rename(stagePath, finalPath); err != nil {
-			cleanup()
-			return nil, daemonError{Code: "internal", Message: fmt.Sprintf("move clip into place: %v", err)}
-		}
-		cleanup = func() { _ = os.RemoveAll(finalPath) }
+	finalPath := filepath.Join(h.registry.ClipsDir(), finalName)
+	if err := moveInstalledClip(stagePath, finalPath); err != nil {
+		cleanup()
+		return nil, daemonError{Code: "internal", Message: fmt.Sprintf("move clip into place: %v", err)}
 	}
+	cleanup = func() { _ = os.RemoveAll(finalPath) }
 
 	clip := ClipConfig{
 		Name:     finalName,
-		Source:   normalizedSource,
+		Package:  firstNonEmpty(strings.TrimSpace(ref.Package), manifestPackage(manifest)),
+		Version:  firstNonEmpty(strings.TrimSpace(ref.Version), manifestVersion(manifest)),
+		Source:   ref.Source,
 		Path:     finalPath,
 		Token:    params.Token,
-		Manifest: manifest,
+		Manifest: cloneManifest(manifest),
 	}
-	if manifest != nil {
-		clip.Manifest = manifest
+	if clip.Manifest != nil {
 		clip.Manifest.Name = finalName
+		if clip.Package != "" {
+			clip.Manifest.Package = clip.Package
+		}
+		if clip.Version != "" {
+			clip.Manifest.Version = clip.Version
+		}
+		clip.Manifest = finalizeManifestCache(clip.Manifest)
 	}
 
 	if err := h.registry.PutClip(clip); err != nil {
@@ -187,6 +160,10 @@ func (h *Handler) addClip(ctx context.Context, params AddParams) (*AddResult, er
 		return nil, daemonError{Code: "internal", Message: fmt.Sprintf("start clip: %v", err)}
 	}
 
+	stored, ok, err := h.registry.GetClip(finalName)
+	if err == nil && ok {
+		clip = stored
+	}
 	return &AddResult{Clip: clip}, nil
 }
 
@@ -228,157 +205,11 @@ func (h *Handler) removeClip(params RemoveParams) (*RemoveResult, error) {
 }
 
 func (h *Handler) inspectClip(ctx context.Context, clip ClipConfig) (*ManifestCache, error) {
-	tempFile, err := os.CreateTemp(h.registry.RootDir(), ".inspect-*.json")
-	if err != nil {
-		return nil, err
-	}
-	tempPath := tempFile.Name()
-	if err := tempFile.Close(); err != nil {
-		return nil, err
-	}
-	if err := os.Remove(tempPath); err != nil && !os.IsNotExist(err) {
-		return nil, err
-	}
-
-	tempRegistry, err := NewRegistry(tempPath)
-	if err != nil {
-		return nil, err
-	}
-	pm, err := NewProcessManager(tempRegistry, h.process.BunPath(), h.process.PinixURL())
-	if err != nil {
-		return nil, err
-	}
-	pm.provider = h.process.provider
-	pm.SetHubClient(h.process.hub, h.process.hubToken)
-	if err := tempRegistry.PutClip(clip); err != nil {
-		return nil, err
-	}
-	defer func() {
-		_ = pm.StopClip(clip.Name)
-		_, _, _ = tempRegistry.RemoveClip(clip.Name)
-		_ = os.Remove(tempRegistry.Path())
-		_ = os.Remove(tempRegistry.Path() + ".lock")
-	}()
-	return pm.LoadManifest(ctx, clip.Name)
+	return InspectClipManifest(ctx, clip, h.process.BunPath(), h.process.PinixURL(), h.process.provider, h.process.hub, h.process.hubToken)
 }
 
 func (h *Handler) requireSuperToken(token string) error {
 	return requireSuperToken(h.registry, token)
-}
-
-type sourceKind string
-
-const (
-	sourceTypeNPM    sourceKind = "npm"
-	sourceTypeGitHub sourceKind = "github"
-	sourceTypeLocal  sourceKind = "local"
-)
-
-func classifySource(source string) (sourceKind, string, error) {
-	source = strings.TrimSpace(source)
-	if source == "" {
-		return "", "", daemonError{Code: "invalid_argument", Message: "source is required"}
-	}
-	if strings.HasPrefix(source, "npm:") {
-		pkg := strings.TrimSpace(strings.TrimPrefix(source, "npm:"))
-		if pkg == "" {
-			return "", "", daemonError{Code: "invalid_argument", Message: "npm source is empty"}
-		}
-		return sourceTypeNPM, "npm:" + pkg, nil
-	}
-	if strings.HasPrefix(source, "github:") {
-		repo := strings.TrimSpace(strings.TrimPrefix(source, "github:"))
-		if repo == "" {
-			return "", "", daemonError{Code: "invalid_argument", Message: "github source is empty"}
-		}
-		return sourceTypeGitHub, "github:" + repo, nil
-	}
-	if _, err := os.Stat(source); err == nil {
-		return sourceTypeLocal, source, nil
-	}
-	if strings.Contains(source, "/") || strings.HasPrefix(source, ".") || strings.HasPrefix(source, "~") {
-		if strings.HasPrefix(source, "~") {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return "", "", daemonError{Code: "internal", Message: fmt.Sprintf("get home dir: %v", err)}
-			}
-			if source == "~" {
-				source = home
-			} else {
-				source = filepath.Join(home, strings.TrimPrefix(source, "~/"))
-			}
-		}
-		return sourceTypeLocal, source, nil
-	}
-	return sourceTypeNPM, "npm:" + source, nil
-}
-
-func deriveNameFromSource(source string) string {
-	source = strings.TrimPrefix(source, "npm:")
-	source = strings.TrimPrefix(source, "github:")
-	source = strings.TrimSuffix(source, ".git")
-	if idx := strings.Index(source, "#"); idx >= 0 {
-		source = source[:idx]
-	}
-	base := filepath.Base(source)
-	base = strings.TrimPrefix(base, "clip-")
-	base = strings.TrimPrefix(base, "@")
-	if strings.Contains(base, "/") {
-		base = filepath.Base(base)
-	}
-	return normalizeName(base)
-}
-
-func normalizeName(name string) string {
-	name = strings.TrimSpace(strings.ToLower(name))
-	var b strings.Builder
-	prevDash := false
-	for _, r := range name {
-		switch {
-		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
-			b.WriteRune(r)
-			prevDash = false
-		case r == '-', r == '_', r == '.', r == ' ':
-			if b.Len() > 0 && !prevDash {
-				b.WriteByte('-')
-				prevDash = true
-			}
-		}
-	}
-	return strings.Trim(b.String(), "-")
-}
-
-func installFromNPM(targetPath, source, bunPath string) error {
-	pkg := strings.TrimPrefix(source, "npm:")
-	if err := os.MkdirAll(targetPath, 0o755); err != nil {
-		return fmt.Errorf("create clip dir: %w", err)
-	}
-	packageJSON := []byte("{\n  \"name\": \"pinix-clip-host\",\n  \"private\": true\n}\n")
-	if err := os.WriteFile(filepath.Join(targetPath, "package.json"), packageJSON, 0o644); err != nil {
-		return fmt.Errorf("write package.json: %w", err)
-	}
-	cmd := exec.Command(bunPath, "add", pkg)
-	cmd.Dir = targetPath
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("bun add %s: %w: %s", pkg, err, strings.TrimSpace(string(output)))
-	}
-	return nil
-}
-
-func installFromGitHub(targetPath, source, bunPath string) error {
-	repo := strings.TrimPrefix(source, "github:")
-	url := fmt.Sprintf("https://github.com/%s.git", strings.TrimSuffix(repo, ".git"))
-	clone := exec.Command("git", "clone", url, targetPath)
-	if output, err := clone.CombinedOutput(); err != nil {
-		return fmt.Errorf("git clone %s: %w: %s", url, err, strings.TrimSpace(string(output)))
-	}
-	install := exec.Command(bunPath, "install")
-	install.Dir = targetPath
-	if output, err := install.CombinedOutput(); err != nil {
-		return fmt.Errorf("bun install: %w: %s", err, strings.TrimSpace(string(output)))
-	}
-	return nil
 }
 
 func removeInstalledPath(clip ClipConfig) error {
@@ -399,6 +230,29 @@ func removeInstalledPath(clip ClipConfig) error {
 		return fmt.Errorf("remove clip dir: %w", err)
 	}
 	return nil
+}
+
+func manifestPackage(manifest *ManifestCache) string {
+	if manifest == nil {
+		return ""
+	}
+	return strings.TrimSpace(manifest.Package)
+}
+
+func manifestVersion(manifest *ManifestCache) string {
+	if manifest == nil {
+		return ""
+	}
+	return strings.TrimSpace(manifest.Version)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 type daemonError struct {

--- a/internal/daemon/inspect.go
+++ b/internal/daemon/inspect.go
@@ -1,0 +1,45 @@
+// Role:    Temporary Clip manifest inspection helpers used by runtime installs and local publish flows
+// Depends: context, os, path/filepath, internal/client
+// Exports: InspectClipManifest
+
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	clientpkg "github.com/epiral/pinix/internal/client"
+)
+
+func InspectClipManifest(ctx context.Context, clip ClipConfig, bunPath, pinixURL string, provider *ProviderManager, hub *clientpkg.Client, hubToken string) (*ManifestCache, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	tempRoot, err := os.MkdirTemp("", "pinix-inspect-*")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(tempRoot)
+
+	tempRegistry, err := NewRegistry(filepath.Join(tempRoot, "config.json"))
+	if err != nil {
+		return nil, err
+	}
+	pm, err := NewProcessManager(tempRegistry, bunPath, pinixURL)
+	if err != nil {
+		return nil, err
+	}
+	pm.provider = provider
+	pm.SetHubClient(hub, hubToken)
+	if err := tempRegistry.PutClip(clip); err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = pm.StopClip(clip.Name)
+		_, _, _ = tempRegistry.RemoveClip(clip.Name)
+	}()
+
+	return pm.LoadManifest(ctx, clip.Name)
+}

--- a/internal/daemon/install.go
+++ b/internal/daemon/install.go
@@ -1,0 +1,271 @@
+// Role:    Clip installation helpers for npm, GitHub, registry tarballs, and local source copies
+// Depends: archive/tar, compress/gzip, context, fmt, io, io/fs, os, os/exec, path/filepath, strings, internal/client
+// Exports: (package-internal helpers)
+
+package daemon
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	clientpkg "github.com/epiral/pinix/internal/client"
+)
+
+func (h *Handler) installClip(ctx context.Context, ref sourceRef, targetPath string) (sourceRef, string, error) {
+	if err := os.MkdirAll(targetPath, 0o755); err != nil {
+		return sourceRef{}, "", daemonError{Code: "internal", Message: fmt.Sprintf("create clip dir: %v", err)}
+	}
+
+	switch ref.Kind {
+	case sourceTypeNPM:
+		if err := installFromNPM(targetPath, ref.Source, h.process.BunPath()); err != nil {
+			return sourceRef{}, "", daemonError{Code: "internal", Message: err.Error()}
+		}
+		return ref, targetPath, nil
+	case sourceTypeRegistry:
+		version, err := installFromRegistry(ctx, targetPath, ref, h.process.BunPath())
+		if err != nil {
+			return sourceRef{}, "", daemonError{Code: "internal", Message: err.Error()}
+		}
+		ref.Version = version
+		ref.Source = canonicalRegistrySource(ref.Registry, ref.Package, version)
+		return ref, targetPath, nil
+	case sourceTypeGitHub:
+		if err := installFromGitHub(targetPath, ref.Source, h.process.BunPath()); err != nil {
+			return sourceRef{}, "", daemonError{Code: "internal", Message: err.Error()}
+		}
+		return ref, targetPath, nil
+	case sourceTypeLocal:
+		info, err := os.Stat(ref.Source)
+		if err != nil {
+			return sourceRef{}, "", daemonError{Code: "not_found", Message: fmt.Sprintf("local clip path %s not found", ref.Source)}
+		}
+		if !info.IsDir() {
+			return sourceRef{}, "", daemonError{Code: "invalid_argument", Message: fmt.Sprintf("local clip path %s is not a directory", ref.Source)}
+		}
+		if err := copyDirectory(ref.Source, targetPath); err != nil {
+			return sourceRef{}, "", daemonError{Code: "internal", Message: fmt.Sprintf("copy local clip: %v", err)}
+		}
+		if err := runBunInstall(targetPath, h.process.BunPath()); err != nil {
+			return sourceRef{}, "", daemonError{Code: "internal", Message: err.Error()}
+		}
+		return ref, targetPath, nil
+	default:
+		return sourceRef{}, "", daemonError{Code: "invalid_argument", Message: fmt.Sprintf("unsupported source %q", ref.Source)}
+	}
+}
+
+func installFromNPM(targetPath, source, bunPath string) error {
+	pkg := strings.TrimSpace(strings.TrimPrefix(source, "npm:"))
+	if pkg == "" {
+		return fmt.Errorf("npm source is empty")
+	}
+	packageJSON := []byte("{\n  \"name\": \"pinix-clip-host\",\n  \"private\": true\n}\n")
+	if err := os.WriteFile(filepath.Join(targetPath, "package.json"), packageJSON, 0o644); err != nil {
+		return fmt.Errorf("write package.json: %w", err)
+	}
+	cmd := exec.Command(bunPath, "add", pkg)
+	cmd.Dir = targetPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("bun add %s: %w: %s", pkg, err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func installFromRegistry(ctx context.Context, targetPath string, ref sourceRef, bunPath string) (string, error) {
+	registryClient, err := clientpkg.NewRegistry(ref.Registry)
+	if err != nil {
+		return "", err
+	}
+	packageDoc, err := registryClient.GetPackage(ctx, ref.Package)
+	if err != nil {
+		return "", err
+	}
+	resolvedVersion, versionDoc, err := packageDoc.ResolveVersion(ref.Version)
+	if err != nil {
+		return "", err
+	}
+	if versionDoc == nil || versionDoc.Dist == nil || strings.TrimSpace(versionDoc.Dist.Tarball) == "" {
+		return "", fmt.Errorf("registry package %q version %q does not provide a tarball", ref.Package, resolvedVersion)
+	}
+	tarball, err := registryClient.Download(ctx, versionDoc.Dist.Tarball)
+	if err != nil {
+		return "", err
+	}
+	if err := extractTarGz(targetPath, tarball); err != nil {
+		return "", err
+	}
+	if err := runBunInstall(targetPath, bunPath); err != nil {
+		return "", err
+	}
+	return resolvedVersion, nil
+}
+
+func installFromGitHub(targetPath, source, bunPath string) error {
+	repo := strings.TrimSpace(strings.TrimPrefix(source, "github:"))
+	url := fmt.Sprintf("https://github.com/%s.git", strings.TrimSuffix(repo, ".git"))
+	clone := exec.Command("git", "clone", url, targetPath)
+	if output, err := clone.CombinedOutput(); err != nil {
+		return fmt.Errorf("git clone %s: %w: %s", url, err, strings.TrimSpace(string(output)))
+	}
+	return runBunInstall(targetPath, bunPath)
+}
+
+func runBunInstall(targetPath, bunPath string) error {
+	if !isRegularFile(filepath.Join(targetPath, "package.json")) {
+		return nil
+	}
+	install := exec.Command(bunPath, "install")
+	install.Dir = targetPath
+	if output, err := install.CombinedOutput(); err != nil {
+		return fmt.Errorf("bun install: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func moveInstalledClip(stagePath, finalPath string) error {
+	if stagePath == finalPath {
+		return nil
+	}
+	_ = os.RemoveAll(finalPath)
+	return os.Rename(stagePath, finalPath)
+}
+
+func extractTarGz(targetPath string, data []byte) error {
+	gzipReader, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("open tarball: %w", err)
+	}
+	defer gzipReader.Close()
+
+	tarReader := tar.NewReader(gzipReader)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read tarball entry: %w", err)
+		}
+
+		name := strings.TrimSpace(header.Name)
+		if name == "" {
+			continue
+		}
+		name = strings.TrimPrefix(name, "./")
+		if strings.HasPrefix(name, "package/") {
+			name = strings.TrimPrefix(name, "package/")
+		}
+		name = filepath.Clean(name)
+		if name == "." || name == "" {
+			continue
+		}
+
+		target := filepath.Join(targetPath, name)
+		if !isWithinDir(target, targetPath) {
+			return fmt.Errorf("tarball entry %q escapes target dir", header.Name)
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, header.FileInfo().Mode().Perm()); err != nil {
+				return fmt.Errorf("create tarball dir %s: %w", target, err)
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("create tarball parent %s: %w", filepath.Dir(target), err)
+			}
+			file, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, header.FileInfo().Mode().Perm())
+			if err != nil {
+				return fmt.Errorf("create tarball file %s: %w", target, err)
+			}
+			if _, err := io.Copy(file, tarReader); err != nil {
+				file.Close()
+				return fmt.Errorf("write tarball file %s: %w", target, err)
+			}
+			if err := file.Close(); err != nil {
+				return fmt.Errorf("close tarball file %s: %w", target, err)
+			}
+		case tar.TypeSymlink:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("create tarball symlink parent %s: %w", filepath.Dir(target), err)
+			}
+			if err := os.Symlink(header.Linkname, target); err != nil {
+				return fmt.Errorf("create tarball symlink %s: %w", target, err)
+			}
+		}
+	}
+}
+
+func copyDirectory(sourceDir, targetDir string) error {
+	return filepath.WalkDir(sourceDir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(sourceDir, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return os.MkdirAll(targetDir, 0o755)
+		}
+		top := strings.Split(rel, string(os.PathSeparator))[0]
+		if top == ".git" || top == "node_modules" {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		targetPath := filepath.Join(targetDir, rel)
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			linkTarget, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+				return err
+			}
+			return os.Symlink(linkTarget, targetPath)
+		}
+		if entry.IsDir() {
+			return os.MkdirAll(targetPath, info.Mode().Perm())
+		}
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+			return err
+		}
+		return copyFile(path, targetPath, info.Mode().Perm())
+	})
+}
+
+func copyFile(sourcePath, targetPath string, mode fs.FileMode) error {
+	src, err := os.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	dst, err := os.OpenFile(targetPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(dst, src); err != nil {
+		dst.Close()
+		return err
+	}
+	return dst.Close()
+}

--- a/internal/daemon/manifest.go
+++ b/internal/daemon/manifest.go
@@ -1,10 +1,11 @@
 // Role:    Manifest enrichment helpers shared by local and provider-backed clips
-// Depends: fmt, os, path/filepath, sort, strings, gopkg.in/yaml.v3
+// Depends: encoding/json, fmt, os, path/filepath, sort, strings, gopkg.in/yaml.v3
 // Exports: (package-internal helpers)
 
 package daemon
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -22,13 +23,79 @@ type clipYAML struct {
 	Patterns     []string `yaml:"patterns"`
 }
 
+type pinixJSON struct {
+	Name         string                 `json:"name"`
+	Version      string                 `json:"version"`
+	Type         string                 `json:"type,omitempty"`
+	Description  string                 `json:"description,omitempty"`
+	Domain       string                 `json:"domain,omitempty"`
+	Runtime      string                 `json:"runtime,omitempty"`
+	Main         string                 `json:"main,omitempty"`
+	Web          string                 `json:"web,omitempty"`
+	Commands     []pinixJSONCommand     `json:"commands,omitempty"`
+	Dependencies map[string]string      `json:"dependencies,omitempty"`
+	Patterns     []string               `json:"patterns,omitempty"`
+	Extra        map[string]interface{} `json:"-"`
+}
+
+type pinixJSONCommand struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Input       json.RawMessage `json:"input,omitempty"`
+	Output      json.RawMessage `json:"output,omitempty"`
+}
+
+type packageJSON struct {
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	Description string `json:"description,omitempty"`
+	Main        string `json:"main,omitempty"`
+	Bin         any    `json:"bin,omitempty"`
+}
+
+type projectMetadata struct {
+	Package      string
+	Version      string
+	Description  string
+	Domain       string
+	Main         string
+	Web          string
+	Dependencies []string
+	Patterns     []string
+	Commands     []CommandInfo
+}
+
 func enrichManifestForClip(clip ClipConfig, manifest *ManifestCache) *ManifestCache {
 	merged := cloneManifest(manifest)
 	if merged == nil {
 		merged = &ManifestCache{}
 	}
 
-	if meta, err := readClipYAMLMetadata(clip.Path); err == nil {
+	if meta, err := loadProjectMetadata(clip); err == nil {
+		if merged.Package == "" {
+			merged.Package = strings.TrimSpace(meta.Package)
+		}
+		if merged.Version == "" {
+			merged.Version = strings.TrimSpace(meta.Version)
+		}
+		if merged.Domain == "" {
+			merged.Domain = strings.TrimSpace(meta.Domain)
+		}
+		if merged.Description == "" {
+			merged.Description = strings.TrimSpace(meta.Description)
+		}
+		if len(merged.Dependencies) == 0 {
+			merged.Dependencies = normalizeStrings(meta.Dependencies)
+		}
+		if len(merged.Patterns) == 0 {
+			merged.Patterns = normalizeStrings(meta.Patterns)
+		}
+		if len(merged.CommandDetails) == 0 {
+			merged.CommandDetails = normalizeCommandDetails(meta.Commands)
+		}
+	}
+
+	if meta, err := readClipYAMLMetadata(clipProjectDir(clip)); err == nil {
 		if merged.Name == "" {
 			merged.Name = strings.TrimSpace(meta.Name)
 		}
@@ -50,7 +117,10 @@ func enrichManifestForClip(clip ClipConfig, manifest *ManifestCache) *ManifestCa
 	}
 
 	if merged.Package == "" {
-		merged.Package = derivePackageName(clip)
+		merged.Package = firstNonEmpty(strings.TrimSpace(clip.Package), derivePackageName(clip))
+	}
+	if merged.Version == "" {
+		merged.Version = strings.TrimSpace(clip.Version)
 	}
 	if merged.Name == "" {
 		merged.Name = strings.TrimSpace(clip.Name)
@@ -59,7 +129,7 @@ func enrichManifestForClip(clip ClipConfig, manifest *ManifestCache) *ManifestCa
 		merged.CommandDetails = synthesizeCommandDetails(merged.Commands)
 	}
 	if len(merged.CommandDetails) == 0 {
-		if names, err := readCommandNames(clip.Path); err == nil {
+		if names, err := readCommandNames(clipProjectDir(clip)); err == nil {
 			merged.CommandDetails = synthesizeCommandDetails(names)
 		}
 	}
@@ -67,10 +137,218 @@ func enrichManifestForClip(clip ClipConfig, manifest *ManifestCache) *ManifestCa
 		merged.Commands = commandNames(merged.CommandDetails)
 	}
 	if !merged.HasWeb {
-		merged.HasWeb = dirExists(filepath.Join(clip.Path, "web"))
+		merged.HasWeb = clipHasWebAssets(clip)
 	}
 
 	return finalizeManifestCache(merged)
+}
+
+func loadProjectMetadata(clip ClipConfig) (*projectMetadata, error) {
+	workdir := clipProjectDir(clip)
+	if strings.TrimSpace(workdir) == "" {
+		return nil, fmt.Errorf("clip path is required")
+	}
+
+	meta := &projectMetadata{}
+	if pinixMeta, err := readPinixJSONMetadata(workdir); err == nil {
+		mergeProjectMetadata(meta, pinixMeta)
+	}
+	if packageMeta, err := readPackageJSONMetadata(workdir); err == nil {
+		mergeProjectMetadata(meta, packageMeta)
+	}
+	if meta.Package == "" && strings.TrimSpace(clip.Package) != "" {
+		meta.Package = strings.TrimSpace(clip.Package)
+	}
+	if meta.Version == "" && strings.TrimSpace(clip.Version) != "" {
+		meta.Version = strings.TrimSpace(clip.Version)
+	}
+	return meta, nil
+}
+
+func mergeProjectMetadata(target, source *projectMetadata) {
+	if target == nil || source == nil {
+		return
+	}
+	if target.Package == "" {
+		target.Package = strings.TrimSpace(source.Package)
+	}
+	if target.Version == "" {
+		target.Version = strings.TrimSpace(source.Version)
+	}
+	if target.Description == "" {
+		target.Description = strings.TrimSpace(source.Description)
+	}
+	if target.Domain == "" {
+		target.Domain = strings.TrimSpace(source.Domain)
+	}
+	if target.Main == "" {
+		target.Main = strings.TrimSpace(source.Main)
+	}
+	if target.Web == "" {
+		target.Web = strings.TrimSpace(source.Web)
+	}
+	if len(target.Dependencies) == 0 {
+		target.Dependencies = normalizeStrings(source.Dependencies)
+	}
+	if len(target.Patterns) == 0 {
+		target.Patterns = normalizeStrings(source.Patterns)
+	}
+	if len(target.Commands) == 0 {
+		target.Commands = normalizeCommandDetails(source.Commands)
+	}
+}
+
+func clipProjectDir(clip ClipConfig) string {
+	base := strings.TrimSpace(clip.Path)
+	if base == "" {
+		return ""
+	}
+	if strings.HasPrefix(strings.TrimSpace(clip.Source), "npm:") {
+		pkg := strings.TrimSpace(clip.Package)
+		if pkg == "" {
+			pkg = strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(clip.Source, "npm:"), "registry:"))
+			pkg, _ = splitPackageVersion(pkg)
+		}
+		if pkg != "" {
+			moduleDir := filepath.Join(base, "node_modules", filepath.FromSlash(pkg))
+			if dirExists(moduleDir) {
+				return moduleDir
+			}
+		}
+	}
+	return base
+}
+
+func clipHasWebAssets(clip ClipConfig) bool {
+	workdir := clipProjectDir(clip)
+	meta, _ := loadProjectMetadata(clip)
+	webDir := "web"
+	if meta != nil && strings.TrimSpace(meta.Web) != "" {
+		webDir = strings.TrimSpace(meta.Web)
+	}
+	return dirExists(filepath.Join(workdir, webDir))
+}
+
+func clipWebDir(clip ClipConfig) string {
+	workdir := clipProjectDir(clip)
+	meta, _ := loadProjectMetadata(clip)
+	if meta != nil && strings.TrimSpace(meta.Web) != "" {
+		return filepath.Join(workdir, strings.TrimSpace(meta.Web))
+	}
+	return filepath.Join(workdir, "web")
+}
+
+func clipEntrypointHint(clip ClipConfig) string {
+	workdir := clipProjectDir(clip)
+	meta, _ := loadProjectMetadata(clip)
+	if meta == nil {
+		return ""
+	}
+	if strings.TrimSpace(meta.Main) != "" {
+		return filepath.Join(workdir, strings.TrimSpace(meta.Main))
+	}
+	return ""
+}
+
+func readPinixJSONMetadata(workdir string) (*projectMetadata, error) {
+	data, err := os.ReadFile(filepath.Join(workdir, "pinix.json"))
+	if err != nil {
+		return nil, err
+	}
+	var raw pinixJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	meta := &projectMetadata{
+		Package:      strings.TrimSpace(raw.Name),
+		Version:      strings.TrimSpace(raw.Version),
+		Description:  strings.TrimSpace(raw.Description),
+		Domain:       strings.TrimSpace(raw.Domain),
+		Main:         strings.TrimSpace(raw.Main),
+		Web:          strings.TrimSpace(raw.Web),
+		Dependencies: mapKeys(raw.Dependencies),
+		Patterns:     normalizeStrings(raw.Patterns),
+		Commands:     pinixCommandsToInternal(raw.Commands),
+	}
+	return meta, nil
+}
+
+func readPackageJSONMetadata(workdir string) (*projectMetadata, error) {
+	data, err := os.ReadFile(filepath.Join(workdir, "package.json"))
+	if err != nil {
+		return nil, err
+	}
+	var raw packageJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	meta := &projectMetadata{
+		Package:     strings.TrimSpace(raw.Name),
+		Version:     strings.TrimSpace(raw.Version),
+		Description: strings.TrimSpace(raw.Description),
+		Main:        firstNonEmpty(strings.TrimSpace(raw.Main), packageJSONBin(raw)),
+	}
+	return meta, nil
+}
+
+func packageJSONBin(raw packageJSON) string {
+	switch value := raw.Bin.(type) {
+	case string:
+		return strings.TrimSpace(value)
+	case map[string]any:
+		for _, item := range value {
+			if path, ok := item.(string); ok && strings.TrimSpace(path) != "" {
+				return strings.TrimSpace(path)
+			}
+		}
+	case map[string]string:
+		for _, item := range value {
+			if strings.TrimSpace(item) != "" {
+				return strings.TrimSpace(item)
+			}
+		}
+	}
+	return ""
+}
+
+func pinixCommandsToInternal(commands []pinixJSONCommand) []CommandInfo {
+	result := make([]CommandInfo, 0, len(commands))
+	for _, command := range commands {
+		name := strings.TrimSpace(command.Name)
+		if name == "" {
+			continue
+		}
+		result = append(result, CommandInfo{
+			Name:        name,
+			Description: strings.TrimSpace(command.Description),
+			Input:       rawSchemaString(command.Input),
+			Output:      rawSchemaString(command.Output),
+		})
+	}
+	return normalizeCommandDetails(result)
+}
+
+func rawSchemaString(raw json.RawMessage) string {
+	raw = json.RawMessage(strings.TrimSpace(string(raw)))
+	if len(raw) == 0 {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return strings.TrimSpace(text)
+	}
+	return strings.TrimSpace(string(raw))
+}
+
+func mapKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		keys = append(keys, strings.TrimSpace(key))
+	}
+	return normalizeStrings(keys)
 }
 
 func cloneManifest(manifest *ManifestCache) *ManifestCache {
@@ -219,7 +497,12 @@ func derivePackageName(clip ClipConfig) string {
 	source := strings.TrimSpace(clip.Source)
 	switch {
 	case strings.HasPrefix(source, "npm:"):
-		return strings.TrimSpace(strings.TrimPrefix(source, "npm:"))
+		pkg, _ := splitPackageVersion(strings.TrimSpace(strings.TrimPrefix(source, "npm:")))
+		return strings.TrimSpace(pkg)
+	case strings.HasPrefix(source, "registry:"):
+		if ref, err := parseSource(source); err == nil {
+			return strings.TrimSpace(ref.Package)
+		}
 	case strings.HasPrefix(source, "github:"):
 		repo := strings.TrimSpace(strings.TrimPrefix(source, "github:"))
 		if repo == "" {

--- a/internal/daemon/process.go
+++ b/internal/daemon/process.go
@@ -274,7 +274,7 @@ func (m *ProcessManager) startLocked(clip ClipConfig) (*clipProcess, error) {
 	}
 
 	cmd := exec.Command(m.bunPath, "run", entrypoint, "--ipc")
-	cmd.Dir = clip.Path
+	cmd.Dir = clipProjectDir(clip)
 	cmd.Env = append(os.Environ(), fmt.Sprintf("PINIX_URL=%s", m.pinixURL))
 
 	stdin, err := cmd.StdinPipe()
@@ -603,6 +603,8 @@ func (m *ProcessManager) persistRegisteredManifest(clip ClipConfig, manifest *Ma
 		return nil
 	}
 	updated.Name = strings.TrimSpace(stored.Name)
+	stored.Package = firstNonEmpty(strings.TrimSpace(updated.Package), strings.TrimSpace(stored.Package))
+	stored.Version = firstNonEmpty(strings.TrimSpace(updated.Version), strings.TrimSpace(stored.Version))
 	stored.Manifest = finalizeManifestCache(updated)
 	if err := m.registry.PutClip(stored); err != nil {
 		return fmt.Errorf("save clip %s manifest: %w", clip.Name, err)
@@ -876,20 +878,25 @@ func findBunBinary() (string, error) {
 }
 
 func resolveEntrypoint(clip ClipConfig) (string, error) {
-	indexPath := filepath.Join(clip.Path, "index.ts")
+	if hint := clipEntrypointHint(clip); isRegularFile(hint) {
+		return hint, nil
+	}
+
+	workdir := clipProjectDir(clip)
+	indexPath := filepath.Join(workdir, "index.ts")
 	if isRegularFile(indexPath) {
 		return indexPath, nil
 	}
 
 	if strings.HasPrefix(clip.Source, "npm:") {
-		pkg := strings.TrimPrefix(clip.Source, "npm:")
+		pkg := firstNonEmpty(strings.TrimSpace(clip.Package), strings.TrimPrefix(clip.Source, "npm:"))
 		npmPath := filepath.Join(clip.Path, "node_modules", filepath.FromSlash(pkg), "index.ts")
 		if isRegularFile(npmPath) {
 			return npmPath, nil
 		}
 	}
 
-	return "", fmt.Errorf("clip %s entrypoint not found under %s", clip.Name, clip.Path)
+	return "", fmt.Errorf("clip %s entrypoint not found under %s", clip.Name, workdir)
 }
 
 func isRegularFile(path string) bool {
@@ -999,6 +1006,8 @@ func registeredManifestForClip(clip ClipConfig, manifest *ipc.Manifest) (*Manife
 
 	registered := &ManifestCache{
 		Name:         strings.TrimSpace(manifest.Name),
+		Package:      firstNonEmpty(strings.TrimSpace(manifest.Package), strings.TrimSpace(clip.Package)),
+		Version:      firstNonEmpty(strings.TrimSpace(manifest.Version), strings.TrimSpace(clip.Version)),
 		Domain:       strings.TrimSpace(manifest.Domain),
 		Description:  strings.TrimSpace(manifest.Description),
 		Commands:     normalizeCommands(extractCommandsJSON(manifest.Commands)),

--- a/internal/daemon/registry.go
+++ b/internal/daemon/registry.go
@@ -16,6 +16,8 @@ import (
 
 type ClipConfig struct {
 	Name     string         `json:"name"`
+	Package  string         `json:"package,omitempty"`
+	Version  string         `json:"version,omitempty"`
 	Source   string         `json:"source"`
 	Path     string         `json:"path"`
 	Token    string         `json:"token,omitempty"`

--- a/internal/daemon/source.go
+++ b/internal/daemon/source.go
@@ -1,0 +1,273 @@
+// Role:    Clip source parsing helpers for npm, registry, GitHub, and local runtime installs
+// Depends: fmt, net/url, os, path/filepath, strings
+// Exports: (package-internal helpers)
+
+package daemon
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type sourceKind string
+
+const (
+	sourceTypeNPM      sourceKind = "npm"
+	sourceTypeRegistry sourceKind = "registry"
+	sourceTypeGitHub   sourceKind = "github"
+	sourceTypeLocal    sourceKind = "local"
+)
+
+type sourceRef struct {
+	Kind     sourceKind
+	Source   string
+	Package  string
+	Version  string
+	Registry string
+}
+
+func parseSource(source string) (sourceRef, error) {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return sourceRef{}, daemonError{Code: "invalid_argument", Message: "source is required"}
+	}
+
+	if strings.HasPrefix(source, "registry:") {
+		return parseRegistrySource(strings.TrimSpace(strings.TrimPrefix(source, "registry:")))
+	}
+	if strings.HasPrefix(source, "npm:") {
+		return parseNPMSource(strings.TrimSpace(strings.TrimPrefix(source, "npm:")))
+	}
+	if strings.HasPrefix(source, "github:") {
+		repo := strings.TrimSpace(strings.TrimPrefix(source, "github:"))
+		if repo == "" {
+			return sourceRef{}, daemonError{Code: "invalid_argument", Message: "github source is empty"}
+		}
+		return sourceRef{Kind: sourceTypeGitHub, Source: "github:" + repo}, nil
+	}
+	if looksLikeScopedNPMPackage(source) {
+		return parseNPMSource(source)
+	}
+
+	expanded, err := expandUserPath(source)
+	if err != nil {
+		return sourceRef{}, daemonError{Code: "internal", Message: fmt.Sprintf("expand local path: %v", err)}
+	}
+	if _, err := os.Stat(expanded); err == nil {
+		return sourceRef{Kind: sourceTypeLocal, Source: expanded}, nil
+	}
+	if looksLikeLocalPath(source) {
+		return sourceRef{Kind: sourceTypeLocal, Source: expanded}, nil
+	}
+
+	return parseNPMSource(source)
+}
+
+func parseNPMSource(spec string) (sourceRef, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return sourceRef{}, daemonError{Code: "invalid_argument", Message: "npm source is empty"}
+	}
+	pkg, version := splitPackageVersion(spec)
+	if pkg == "" {
+		return sourceRef{}, daemonError{Code: "invalid_argument", Message: fmt.Sprintf("invalid npm source %q", spec)}
+	}
+	if strings.HasSuffix(spec, "@") || strings.HasSuffix(spec, ":") {
+		return sourceRef{}, daemonError{Code: "invalid_argument", Message: fmt.Sprintf("invalid npm version in %q", spec)}
+	}
+	return sourceRef{
+		Kind:    sourceTypeNPM,
+		Source:  canonicalNPMSource(pkg, version),
+		Package: pkg,
+		Version: version,
+	}, nil
+}
+
+func parseRegistrySource(spec string) (sourceRef, error) {
+	spec = strings.TrimSpace(spec)
+	registryURL, packageSpec, ok := strings.Cut(spec, "#")
+	if !ok {
+		return sourceRef{}, daemonError{Code: "invalid_argument", Message: "registry source must use registry:<url>#<package>[:version]"}
+	}
+	registryURL = normalizeRegistryURL(registryURL)
+	if registryURL == "" {
+		return sourceRef{}, daemonError{Code: "invalid_argument", Message: "registry URL is required"}
+	}
+	if !isRegistryURL(registryURL) {
+		return sourceRef{}, daemonError{Code: "invalid_argument", Message: fmt.Sprintf("invalid registry URL %q", registryURL)}
+	}
+	pkg, version := splitPackageVersion(packageSpec)
+	if pkg == "" {
+		return sourceRef{}, daemonError{Code: "invalid_argument", Message: fmt.Sprintf("invalid registry package %q", packageSpec)}
+	}
+	if strings.HasSuffix(packageSpec, "@") || strings.HasSuffix(packageSpec, ":") {
+		return sourceRef{}, daemonError{Code: "invalid_argument", Message: fmt.Sprintf("invalid registry version in %q", packageSpec)}
+	}
+	return sourceRef{
+		Kind:     sourceTypeRegistry,
+		Source:   canonicalRegistrySource(registryURL, pkg, version),
+		Package:  pkg,
+		Version:  version,
+		Registry: registryURL,
+	}, nil
+}
+
+func splitPackageVersion(spec string) (string, string) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return "", ""
+	}
+
+	versionIndex := -1
+	if strings.HasPrefix(spec, "@") {
+		slash := strings.Index(spec, "/")
+		if slash <= 1 || slash == len(spec)-1 {
+			return "", ""
+		}
+		if at := strings.LastIndex(spec, "@"); at > slash {
+			versionIndex = at
+		} else if colon := strings.LastIndex(spec, ":"); colon > slash {
+			versionIndex = colon
+		}
+	} else {
+		if at := strings.LastIndex(spec, "@"); at > 0 {
+			versionIndex = at
+		} else if colon := strings.LastIndex(spec, ":"); colon > 0 {
+			versionIndex = colon
+		}
+	}
+
+	if versionIndex <= 0 {
+		return spec, ""
+	}
+	return strings.TrimSpace(spec[:versionIndex]), strings.TrimSpace(spec[versionIndex+1:])
+}
+
+func canonicalNPMSource(pkg, version string) string {
+	pkg = strings.TrimSpace(pkg)
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return "npm:" + pkg
+	}
+	return "npm:" + pkg + "@" + version
+}
+
+func canonicalRegistrySource(registryURL, pkg, version string) string {
+	registryURL = normalizeRegistryURL(registryURL)
+	pkg = strings.TrimSpace(pkg)
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return "registry:" + registryURL + "#" + pkg
+	}
+	return "registry:" + registryURL + "#" + pkg + "@" + version
+}
+
+func normalizeRegistryURL(raw string) string {
+	return strings.TrimRight(strings.TrimSpace(raw), "/")
+}
+
+func isRegistryURL(raw string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return false
+	}
+	return (parsed.Scheme == "http" || parsed.Scheme == "https") && parsed.Host != ""
+}
+
+func deriveNameFromSource(source string) string {
+	ref, err := parseSource(source)
+	if err == nil {
+		switch ref.Kind {
+		case sourceTypeNPM, sourceTypeRegistry:
+			return defaultInstanceName(ref.Package)
+		case sourceTypeGitHub:
+			repo := strings.TrimSpace(strings.TrimPrefix(ref.Source, "github:"))
+			repo = strings.TrimSuffix(repo, ".git")
+			if idx := strings.Index(repo, "#"); idx >= 0 {
+				repo = repo[:idx]
+			}
+			return defaultInstanceName(filepath.Base(repo))
+		case sourceTypeLocal:
+			return defaultInstanceName(filepath.Base(ref.Source))
+		}
+	}
+
+	source = strings.TrimPrefix(source, "npm:")
+	source = strings.TrimPrefix(source, "github:")
+	source = strings.TrimPrefix(source, "registry:")
+	if _, remainder, ok := strings.Cut(source, "#"); ok {
+		source = remainder
+	}
+	source = strings.TrimSuffix(source, ".git")
+	if idx := strings.Index(source, "#"); idx >= 0 {
+		source = source[:idx]
+	}
+	base, _ := splitPackageVersion(source)
+	if base == "" {
+		base = source
+	}
+	return defaultInstanceName(filepath.Base(base))
+}
+
+func defaultInstanceName(value string) string {
+	value = filepath.Base(filepath.FromSlash(strings.TrimSpace(value)))
+	value = strings.TrimPrefix(value, "clip-")
+	value = strings.TrimPrefix(value, "@")
+	return normalizeName(value)
+}
+
+func looksLikeScopedNPMPackage(source string) bool {
+	pkg, _ := splitPackageVersion(source)
+	if !strings.HasPrefix(pkg, "@") {
+		return false
+	}
+	parts := strings.Split(pkg, "/")
+	return len(parts) == 2 && strings.TrimSpace(parts[0]) != "" && strings.TrimSpace(parts[1]) != ""
+}
+
+func looksLikeLocalPath(source string) bool {
+	if source == "" {
+		return false
+	}
+	if strings.Contains(source, "://") {
+		return false
+	}
+	return strings.Contains(source, "/") || strings.HasPrefix(source, ".") || strings.HasPrefix(source, "~")
+}
+
+func expandUserPath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" || !strings.HasPrefix(path, "~") {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	if path == "~" {
+		return home, nil
+	}
+	return filepath.Join(home, strings.TrimPrefix(path, "~/")), nil
+}
+
+func normalizeName(name string) string {
+	name = strings.TrimSpace(strings.ToLower(name))
+	var b strings.Builder
+	prevDash := false
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevDash = false
+		case r == '-', r == '_', r == '.', r == ' ':
+			if b.Len() > 0 && !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -36,6 +36,8 @@ type Message struct {
 
 type Manifest struct {
 	Name         string          `json:"name,omitempty"`
+	Package      string          `json:"package,omitempty"`
+	Version      string          `json:"version,omitempty"`
 	Domain       string          `json:"domain,omitempty"`
 	Description  string          `json:"description,omitempty"`
 	Commands     json.RawMessage `json:"commands,omitempty"`


### PR DESCRIPTION
## Summary
- Clip 实例化模型：每个 Clip 存 name + package + version
- `pinix add --name` 支持自定义实例名，同 package 多实例
- `pinix list` 展示 name、package、version
- pinix.json manifest 支持
- Registry 集成脚手架（--registry flag）

## Test plan
- [x] `go build ./...` 通过
- [x] `pinix add clip-todo` 正常安装
- [x] `pinix add clip-todo --name todo-work` 创建第二个实例
- [x] `pinix list` 显示两个实例，同 package 不同 name
- [x] `pinix todo list` 正常调用

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)