### PR TITLE
feat: Portal UX redesign

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1,5 +1,8 @@
+// ─── Connect-RPC protocol constants ───
+
 const HUB_PROCEDURES = {
   listClips: "/pinix.v2.HubService/ListClips",
+  listProviders: "/pinix.v2.HubService/ListProviders",
   getManifest: "/pinix.v2.HubService/GetManifest",
   invoke: "/pinix.v2.HubService/Invoke",
 };
@@ -19,35 +22,497 @@ const STREAM_HEADERS = {
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
+// ─── Smart form definitions ───
+// Maps command names to form types for non-JSON input
+const SMART_FORMS = {
+  // ── Audio ──
+  speak: {
+    fields: [
+      { name: "text", label: "Text", inputType: "textarea", placeholder: "Enter text to speak..." },
+      { name: "voice", label: "Voice", inputType: "select", options: ["Tingting", "Meijia", "Sinji", "Samantha", "Alex", "Daniel", "Karen", "Victoria"] },
+    ],
+    buildInput: (v) => { const r = { text: v.text || "" }; if (v.voice) r.voice = v.voice; return r; },
+  },
+  setVolume: {
+    fields: [{ name: "level", label: "Volume (0-100)", inputType: "number", placeholder: "50" }],
+    buildInput: (v) => ({ level: parseInt(v.level) || 50 }),
+  },
+  // ── Search / Query ──
+  search: {
+    fields: [{ name: "query", label: "Query", inputType: "text", placeholder: "Search query..." }],
+    buildInput: (v) => ({ query: v.query || "" }),
+  },
+  searchContacts: {
+    fields: [{ name: "query", label: "Name", inputType: "text", placeholder: "Contact name..." }],
+    buildInput: (v) => ({ query: v.query || "" }),
+  },
+  note: {
+    fields: [{ name: "id", label: "Note ID", inputType: "text", placeholder: "Note ID or URL..." }],
+    buildInput: (v) => ({ id: v.id || "" }),
+  },
+  // ── Shell ──
+  exec: {
+    fields: [
+      { name: "command", label: "Command", inputType: "text", placeholder: "e.g. ls -la /tmp" },
+      { name: "cwd", label: "Working Directory", inputType: "text", placeholder: "(optional) /path/to/dir" },
+    ],
+    buildInput: (v) => { const r = { command: v.command || "" }; if (v.cwd) r.cwd = v.cwd; return r; },
+  },
+  execScript: {
+    fields: [
+      { name: "language", label: "Language", inputType: "select", options: ["python3", "bash", "node", "swift", "ruby"] },
+      { name: "code", label: "Code", inputType: "textarea", placeholder: "print('hello world')" },
+    ],
+    buildInput: (v) => ({ language: v.language || "python3", code: v.code || "" }),
+  },
+  // ── Apps ──
+  launch: {
+    fields: [{ name: "app", label: "App Name", inputType: "text", placeholder: "e.g. Safari, Finder, iTerm" }],
+    buildInput: (v) => ({ app: v.app || "" }),
+  },
+  quit: {
+    fields: [{ name: "app", label: "App Name", inputType: "text", placeholder: "App to quit" }],
+    buildInput: (v) => ({ app: v.app || "" }),
+  },
+  focus: {
+    fields: [{ name: "app", label: "App Name", inputType: "text", placeholder: "App to focus" }],
+    buildInput: (v) => ({ app: v.app || "" }),
+  },
+  // ── Notifications ──
+  notify: {
+    fields: [
+      { name: "title", label: "Title", inputType: "text", placeholder: "Notification title" },
+      { name: "body", label: "Body", inputType: "text", placeholder: "Notification body" },
+    ],
+    buildInput: (v) => ({ title: v.title || "", body: v.body || "" }),
+  },
+  alert: {
+    fields: [
+      { name: "title", label: "Title", inputType: "text", placeholder: "Alert title" },
+      { name: "message", label: "Message", inputType: "text", placeholder: "Alert message" },
+    ],
+    buildInput: (v) => ({ title: v.title || "", message: v.message || "" }),
+  },
+  prompt: {
+    fields: [
+      { name: "title", label: "Title", inputType: "text", placeholder: "Prompt title" },
+      { name: "message", label: "Message", inputType: "text", placeholder: "Prompt message" },
+      { name: "defaultAnswer", label: "Default Answer", inputType: "text", placeholder: "(optional)" },
+    ],
+    buildInput: (v) => { const r = { title: v.title || "", message: v.message || "" }; if (v.defaultAnswer) r.defaultAnswer = v.defaultAnswer; return r; },
+  },
+  // ── Clipboard ──
+  write: {
+    fields: [{ name: "content", label: "Content", inputType: "textarea", placeholder: "Text to copy to clipboard" }],
+    buildInput: (v) => ({ content: v.content || "" }),
+  },
+  // ── Filesystem ──
+  getMetadata: {
+    fields: [{ name: "path", label: "File Path", inputType: "text", placeholder: "/path/to/file" }],
+    buildInput: (v) => ({ path: v.path || "" }),
+  },
+  preview: {
+    fields: [{ name: "path", label: "File Path", inputType: "text", placeholder: "/path/to/file" }],
+    buildInput: (v) => ({ path: v.path || "" }),
+  },
+  convertDoc: {
+    fields: [
+      { name: "path", label: "File Path", inputType: "text", placeholder: "/path/to/document" },
+      { name: "format", label: "Format", inputType: "select", options: ["html", "txt", "rtf", "docx"] },
+    ],
+    buildInput: (v) => ({ path: v.path || "", format: v.format || "html" }),
+  },
+  // ── Input ──
+  click: {
+    fields: [
+      { name: "x", label: "X", inputType: "number", placeholder: "500" },
+      { name: "y", label: "Y", inputType: "number", placeholder: "300" },
+    ],
+    buildInput: (v) => ({ x: parseFloat(v.x) || 0, y: parseFloat(v.y) || 0 }),
+  },
+  typeText: {
+    fields: [{ name: "text", label: "Text", inputType: "text", placeholder: "Text to type..." }],
+    buildInput: (v) => ({ text: v.text || "" }),
+  },
+  pressKey: {
+    fields: [
+      { name: "key", label: "Key", inputType: "text", placeholder: "e.g. c" },
+      { name: "modifiers", label: "Modifiers", inputType: "text", placeholder: "e.g. command,shift (comma separated)" },
+    ],
+    buildInput: (v) => { const r = { key: v.key || "" }; if (v.modifiers) r.modifiers = v.modifiers.split(",").map(m => m.trim()); return r; },
+  },
+  // ── Windows ──
+  move: {
+    fields: [
+      { name: "app", label: "App Name", inputType: "text", placeholder: "App name" },
+      { name: "x", label: "X", inputType: "number", placeholder: "0" },
+      { name: "y", label: "Y", inputType: "number", placeholder: "0" },
+    ],
+    buildInput: (v) => ({ app: v.app || "", x: parseInt(v.x) || 0, y: parseInt(v.y) || 0 }),
+  },
+  resize: {
+    fields: [
+      { name: "app", label: "App Name", inputType: "text", placeholder: "App name" },
+      { name: "width", label: "Width", inputType: "number", placeholder: "800" },
+      { name: "height", label: "Height", inputType: "number", placeholder: "600" },
+    ],
+    buildInput: (v) => ({ app: v.app || "", width: parseInt(v.width) || 800, height: parseInt(v.height) || 600 }),
+  },
+  // ── ML ──
+  detectLanguage: {
+    fields: [{ name: "text", label: "Text", inputType: "textarea", placeholder: "Enter text to detect language..." }],
+    buildInput: (v) => ({ text: v.text || "" }),
+  },
+  sentiment: {
+    fields: [{ name: "text", label: "Text", inputType: "textarea", placeholder: "Enter text for sentiment analysis..." }],
+    buildInput: (v) => ({ text: v.text || "" }),
+  },
+  // ── Shortcuts ──
+  run: {
+    fields: [{ name: "name", label: "Shortcut Name", inputType: "text", placeholder: "e.g. 车门上锁" }],
+    buildInput: (v) => ({ name: v.name || "" }),
+  },
+  // ── PIM ──
+  getEvents: {
+    fields: [
+      { name: "from", label: "From Date", inputType: "date", placeholder: "" },
+      { name: "to", label: "To Date", inputType: "date", placeholder: "" },
+    ],
+    buildInput: (v) => ({ from: v.from || "", to: v.to || "" }),
+  },
+  // ── Todo ──
+  add: {
+    fields: [{ name: "title", label: "Title", inputType: "text", placeholder: "Todo item title..." }],
+    buildInput: (v) => ({ title: v.title || "" }),
+  },
+  delete: {
+    fields: [{ name: "id", label: "ID", inputType: "text", placeholder: "Item ID to delete" }],
+    buildInput: (v) => ({ id: v.id || "" }),
+  },
+  // ── Twitter ──
+  getProfile: {
+    fields: [{ name: "username", label: "Username", inputType: "text", placeholder: "@username" }],
+    buildInput: (v) => ({ username: v.username || "" }),
+  },
+  getTweet: {
+    fields: [{ name: "id", label: "Tweet ID", inputType: "text", placeholder: "Tweet ID or URL" }],
+    buildInput: (v) => ({ id: v.id || "" }),
+  },
+  // ── Agent ──
+  send: {
+    fields: [
+      { name: "topic", label: "Topic", inputType: "text", placeholder: "Topic name or ID" },
+      { name: "message", label: "Message", inputType: "textarea", placeholder: "Your message..." },
+    ],
+    buildInput: (v) => ({ topic: v.topic || "", message: v.message || "" }),
+  },
+  "create-topic": {
+    fields: [{ name: "name", label: "Topic Name", inputType: "text", placeholder: "New topic name" }],
+    buildInput: (v) => ({ name: v.name || "" }),
+  },
+  "get-topic": {
+    fields: [{ name: "topic", label: "Topic", inputType: "text", placeholder: "Topic name or ID" }],
+    buildInput: (v) => ({ topic: v.topic || "" }),
+  },
+  "get-run": {
+    fields: [{ name: "runId", label: "Run ID", inputType: "text", placeholder: "Run ID" }],
+    buildInput: (v) => ({ runId: v.runId || "" }),
+  },
+  "cancel-run": {
+    fields: [{ name: "runId", label: "Run ID", inputType: "text", placeholder: "Run ID to cancel" }],
+    buildInput: (v) => ({ runId: v.runId || "" }),
+  },
+};
+
+// Commands that require no input — just a Run button
+const NO_INPUT_COMMANDS = new Set([
+  "screenshot", "list", "listCalendars", "battery", "info",
+  "listWindows", "listApps", "getClipboard", "getBrightness",
+  "getVolume", "listDisplays", "listTabs", "frontmostApp",
+  "getFrontmost", "activeWindow", "listReminders", "listNotes",
+  "screenshotAll", "listContacts", "currentTrack", "systemInfo",
+  "health", "ping", "status", "read", "listTypes",
+  "getCursorPosition", "uptime", "diskUsage", "processes",
+  "interfaces", "wifiInfo", "speedTest", "bluetoothDevices",
+  "list-topics", "event-check", "ocr",
+]);
+
+// ─── Application state ───
+
 const state = {
   clips: [],
+  providers: [],
   selectedClipName: null,
   selectedManifest: null,
   detailError: null,
   expandedCommand: null,
-  inputs: {},
+  inputs: {},          // JSON textarea fallback inputs
+  smartInputs: {},     // smart form field values
   runningCommand: null,
   lastResult: null,
+  searchQuery: "",
+  collapsedGroups: {}, // provider group collapse state
+  resultExpanded: false,
+  connected: true,
 };
 
-const refreshButton = document.getElementById("refreshButton");
-const clipCount = document.getElementById("clipCount");
-const clipList = document.getElementById("clipList");
-const detailView = document.getElementById("detailView");
+// ─── DOM references ───
 
-refreshButton.addEventListener("click", () => {
-  void refreshClips();
+const refreshButton = document.getElementById("refreshButton");
+const refreshProviders = document.getElementById("refreshProviders");
+const clipCountEl = document.getElementById("clipCount");
+const providerCountEl = document.getElementById("providerCount");
+const connectionBadge = document.getElementById("connectionBadge");
+const hubAddressEl = document.getElementById("hubAddress");
+const clipList = document.getElementById("clipList");
+const providerList = document.getElementById("providerList");
+const detailView = document.getElementById("detailView");
+const clipSearch = document.getElementById("clipSearch");
+
+// Set hub address from current page location
+hubAddressEl.textContent = `hub :${window.location.port || "80"}`;
+
+// ─── Event listeners ───
+
+refreshButton.addEventListener("click", () => void refreshClips());
+refreshProviders.addEventListener("click", () => void refreshProviderList());
+
+clipSearch.addEventListener("input", (e) => {
+  state.searchQuery = e.target.value.trim().toLowerCase();
+  renderClipList();
 });
 
-void refreshClips();
+// Cmd+K to focus search
+document.addEventListener("keydown", (e) => {
+  if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+    e.preventDefault();
+    clipSearch.focus();
+    clipSearch.select();
+  }
+});
 
-async function refreshClips() {
-  refreshButton.disabled = true;
-  clipList.innerHTML = '<div class="loading">Loading clips...</div>';
+// Arrow key navigation for clips
+document.addEventListener("keydown", (e) => {
+  // Skip if in input/textarea/select
+  const tag = e.target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+
+  // Get visible clips (respecting search filter)
+  let visibleClips = state.clips;
+  if (state.searchQuery) {
+    visibleClips = state.clips.filter((c) =>
+      c.name.toLowerCase().includes(state.searchQuery) ||
+      (c.provider && c.provider.toLowerCase().includes(state.searchQuery)) ||
+      (c.package && c.package.toLowerCase().includes(state.searchQuery)) ||
+      (c.domain && c.domain.toLowerCase().includes(state.searchQuery))
+    );
+  }
+  if (visibleClips.length === 0) return;
+
+  const clipNames = visibleClips.map((c) => c.name);
+  const idx = clipNames.indexOf(state.selectedClipName);
+
+  if (e.key === "ArrowDown") {
+    e.preventDefault();
+    const next = idx < clipNames.length - 1 ? idx + 1 : 0;
+    void selectClip(clipNames[next]);
+  } else if (e.key === "ArrowUp") {
+    e.preventDefault();
+    const prev = idx > 0 ? idx - 1 : clipNames.length - 1;
+    void selectClip(clipNames[prev]);
+  } else if (e.key === "Enter" && state.selectedClipName && !state.expandedCommand) {
+    e.preventDefault();
+    const clip = getSelectedClip();
+    if (clip) {
+      const commands = getClipCommands(clip);
+      if (commands.length > 0) {
+        const firstCmd = typeof commands[0] === "string" ? commands[0] : commands[0].name;
+        state.expandedCommand = firstCmd;
+        updateHash();
+        renderDetail();
+      }
+    }
+  }
+});
+
+// Quick actions
+document.getElementById("quickActions").addEventListener("click", (e) => {
+  const btn = e.target.closest("[data-qa]");
+  if (!btn) return;
+  const action = btn.dataset.qa;
+  void runQuickAction(action, btn);
+});
+
+// ─── Quick Actions ───
+
+async function runQuickAction(action, btn) {
+  // Find the clip that has this command
+  const actionMap = {
+    "screenshot": { command: "screenshot" },
+    "speak-clipboard": { command: "speak", input: { text: "__CLIPBOARD__" } },
+    "system-info": { command: "info" },
+    "list-windows": { command: "listWindows" },
+  };
+
+  const spec = actionMap[action];
+  if (!spec) return;
+
+  // Find first clip that has this command
+  const clip = state.clips.find((c) => getClipCommands(c).some((cmd) => {
+    const cmdName = typeof cmd === "string" ? cmd : cmd.name;
+    return cmdName === spec.command;
+  }));
+
+  if (!clip) {
+    showToast(`No clip found with command "${spec.command}"`);
+    return;
+  }
+
+  btn.disabled = true;
+  try {
+    let input = spec.input || {};
+
+    // Special case: read clipboard for speak
+    if (action === "speak-clipboard") {
+      try {
+        const clipboardText = await navigator.clipboard.readText();
+        input = { text: clipboardText || "Clipboard is empty" };
+      } catch {
+        input = { text: "Cannot read clipboard" };
+      }
+    }
+
+    const payload = await hubInvoke(clip.name, spec.command, input);
+
+    state.lastResult = {
+      ok: true,
+      clip: clip.name,
+      command: spec.command,
+      meta: "Quick action succeeded",
+      payload,
+    };
+
+    // Select the clip and expand the command so the inline result is visible
+    state.selectedClipName = clip.name;
+    state.selectedManifest = clip.manifest || null;
+    state.expandedCommand = spec.command;
+    updateHash();
+    renderClipList();
+    renderDetail();
+  } catch (error) {
+    state.lastResult = {
+      ok: false,
+      clip: clip.name,
+      command: spec.command,
+      meta: String(error.message || error),
+      payload: { error: String(error.message || error) },
+    };
+    state.selectedClipName = clip.name;
+    state.selectedManifest = clip.manifest || null;
+    state.expandedCommand = spec.command;
+    updateHash();
+    renderClipList();
+    renderDetail();
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+function showToast(message) {
+  // Simple non-blocking toast
+  const toast = document.createElement("div");
+  toast.style.cssText = "position:fixed;bottom:20px;left:50%;transform:translateX(-50%);padding:8px 16px;border-radius:8px;background:var(--c-text);color:var(--c-bg);font-size:12px;z-index:9999;pointer-events:none;opacity:0;transition:opacity 0.2s";
+  toast.textContent = message;
+  document.body.appendChild(toast);
+  requestAnimationFrame(() => { toast.style.opacity = "1"; });
+  setTimeout(() => {
+    toast.style.opacity = "0";
+    setTimeout(() => toast.remove(), 200);
+  }, 2000);
+}
+
+// ─── Hash routing ───
+
+function updateHash() {
+  let hash = "";
+  if (state.selectedClipName) {
+    hash = `clip/${encodeURIComponent(state.selectedClipName)}`;
+    if (state.expandedCommand) hash += `/${encodeURIComponent(state.expandedCommand)}`;
+  }
+  history.replaceState(null, "", hash ? `#${hash}` : window.location.pathname);
+}
+
+function parseHash() {
+  const hash = window.location.hash.slice(1);
+  if (!hash) return null;
+  const match = hash.match(/^clip\/([^/]+)\/?(.*)$/);
+  if (!match) return null;
+  return {
+    clipName: decodeURIComponent(match[1]),
+    command: match[2] ? decodeURIComponent(match[2]) : null,
+  };
+}
+
+window.addEventListener("hashchange", () => {
+  const parsed = parseHash();
+  if (parsed) {
+    if (state.selectedClipName !== parsed.clipName) {
+      state.expandedCommand = parsed.command;
+      void selectClip(parsed.clipName);
+    } else if (state.expandedCommand !== parsed.command) {
+      state.expandedCommand = parsed.command;
+      renderDetail();
+    }
+  } else {
+    state.selectedClipName = null;
+    state.selectedManifest = null;
+    state.expandedCommand = null;
+    state.lastResult = null;
+    renderClipList();
+    renderDetail();
+  }
+});
+
+// ─── Init & auto-refresh ───
+
+void init();
+setInterval(() => {
+  void refreshClips(true);
+  void refreshProviderList();
+}, 30000);
+
+async function init() {
+  await Promise.all([
+    refreshClips(),
+    refreshProviderList(),
+  ]);
+
+  // Restore state from URL hash after data is loaded
+  const parsed = parseHash();
+  if (parsed && parsed.clipName) {
+    state.selectedClipName = parsed.clipName;
+    if (parsed.command) state.expandedCommand = parsed.command;
+    const current = getSelectedClip();
+    if (current) {
+      state.selectedManifest = current.manifest || null;
+      renderClipList();
+      await loadManifest(parsed.clipName, { preserveResult: true });
+    }
+  }
+}
+
+// ─── Data fetching ───
+
+async function refreshClips(silent = false) {
+  if (!silent) {
+    refreshButton.disabled = true;
+    clipList.innerHTML = '<div class="loading">Loading clips...</div>';
+  }
 
   try {
     const payload = await hubUnary(HUB_PROCEDURES.listClips, {});
     state.clips = Array.isArray(payload?.clips) ? payload.clips.map(normalizeClipInfo) : [];
+    state.connected = true;
 
     if (state.selectedClipName) {
       const current = getSelectedClip();
@@ -59,27 +524,53 @@ async function refreshClips() {
       }
     }
 
+    updateConnectionStatus();
     renderClipList();
 
     if (state.selectedClipName) {
       await loadManifest(state.selectedClipName, { preserveResult: true });
-    } else {
+    } else if (!silent) {
       renderDetail();
     }
   } catch (error) {
-    renderClipList(String(error.message || error));
-    detailView.innerHTML = renderNotice(
-      "Unable to load clips",
-      String(error.message || error),
-    );
+    state.connected = false;
+    updateConnectionStatus();
+    if (!silent) {
+      renderClipList(String(error.message || error));
+      detailView.innerHTML = renderNotice(
+        "Unable to load clips",
+        String(error.message || error),
+      );
+    }
   } finally {
     refreshButton.disabled = false;
   }
 }
 
+async function refreshProviderList() {
+  try {
+    const payload = await hubUnary(HUB_PROCEDURES.listProviders, {});
+    state.providers = Array.isArray(payload?.providers) ? payload.providers : [];
+    renderProviderList();
+    providerCountEl.textContent = `${state.providers.length} provider${state.providers.length === 1 ? "" : "s"}`;
+  } catch {
+    // ListProviders may not be available on older hubs; ignore silently
+    state.providers = [];
+    renderProviderList();
+  }
+}
+
+function updateConnectionStatus() {
+  connectionBadge.className = `connection-badge ${state.connected ? "connected" : "disconnected"}`;
+  connectionBadge.textContent = state.connected ? "Connected" : "Disconnected";
+}
+
+// ─── Clip selection & manifest ───
+
 async function selectClip(name) {
   if (state.selectedClipName !== name) {
     state.lastResult = null;
+    state.resultExpanded = false;
   }
 
   state.selectedClipName = name;
@@ -87,6 +578,7 @@ async function selectClip(name) {
   state.detailError = null;
   state.selectedManifest = getSelectedClip()?.manifest || null;
 
+  updateHash();
   renderClipList();
   renderDetail(true);
 
@@ -95,14 +587,10 @@ async function selectClip(name) {
 
 async function loadManifest(name, options = {}) {
   const selected = getSelectedClip();
-  if (!selected || selected.name !== name) {
-    return;
-  }
+  if (!selected || selected.name !== name) return;
 
   state.detailError = null;
-  if (!options.preserveResult) {
-    state.lastResult = null;
-  }
+  if (!options.preserveResult) state.lastResult = null;
 
   try {
     const payload = await hubUnary(HUB_PROCEDURES.getManifest, { clipName: name });
@@ -117,35 +605,69 @@ async function loadManifest(name, options = {}) {
   renderDetail();
 }
 
+// ─── Smart form input handling ───
+
+function getSmartInputKey(clipName, commandName, fieldName) {
+  return `${clipName}:${commandName}:${fieldName}`;
+}
+
+function getSmartInputValue(clipName, commandName, fieldName) {
+  return state.smartInputs[getSmartInputKey(clipName, commandName, fieldName)] || "";
+}
+
+function setSmartInputValue(clipName, commandName, fieldName, value) {
+  state.smartInputs[getSmartInputKey(clipName, commandName, fieldName)] = value;
+}
+
+function buildSmartInput(clipName, commandName) {
+  const form = SMART_FORMS[commandName];
+  if (!form) return null;
+
+  const values = {};
+  for (const field of form.fields) {
+    values[field.name] = getSmartInputValue(clipName, commandName, field.name);
+  }
+  return form.buildInput(values);
+}
+
+// ─── Command invocation ───
+
 async function invokeCommand(commandName) {
   const clip = getSelectedClip();
-  if (!clip) {
-    return;
-  }
+  if (!clip) return;
 
-  const inputText = getCommandInput(clip.name, commandName).trim();
   let input;
 
-  try {
-    input = inputText ? JSON.parse(inputText) : {};
-  } catch (error) {
-    state.lastResult = {
-      ok: false,
-      clip: clip.name,
-      command: commandName,
-      meta: "Invalid JSON input",
-      payload: { error: String(error.message || error) },
-    };
-    renderDetail();
-    return;
+  // Try smart form first
+  const formDef = SMART_FORMS[commandName];
+  if (formDef) {
+    input = buildSmartInput(clip.name, commandName);
+  } else if (NO_INPUT_COMMANDS.has(commandName)) {
+    input = {};
+  } else {
+    // JSON textarea fallback
+    const inputText = getCommandInput(clip.name, commandName).trim();
+    try {
+      input = inputText ? JSON.parse(inputText) : {};
+    } catch (error) {
+      state.lastResult = {
+        ok: false,
+        clip: clip.name,
+        command: commandName,
+        meta: "Invalid JSON input",
+        payload: { error: String(error.message || error) },
+      };
+      renderDetail();
+      return;
+    }
   }
 
   state.runningCommand = commandName;
+  state.resultExpanded = false;
   renderDetail();
 
   try {
     const payload = await hubInvoke(clip.name, commandName, input);
-
     state.lastResult = {
       ok: true,
       clip: clip.name,
@@ -167,54 +689,165 @@ async function invokeCommand(commandName) {
   }
 }
 
+// ─── Rendering: Provider list ───
+
+function relativeTime(dateStr) {
+  if (!dateStr) return "";
+  const then = new Date(dateStr);
+  if (isNaN(then.getTime())) return "";
+  const seconds = Math.floor((Date.now() - then.getTime()) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function renderProviderList() {
+  if (state.providers.length === 0) {
+    providerList.innerHTML = '<div class="empty-list-sm">No providers connected</div>';
+    return;
+  }
+
+  providerList.innerHTML = state.providers.map((p) => {
+    const clipCount = Array.isArray(p.clips) ? p.clips.length : 0;
+    const name = p.name || "unknown";
+    const connectedAt = p.connectedAt || p.connected_at || "";
+    const timeAgo = relativeTime(connectedAt);
+    return `
+      <div class="provider-item">
+        <div class="provider-item-left">
+          <span class="provider-dot"></span>
+          <span class="provider-name" title="${escapeHTML(name)}">${escapeHTML(name)}</span>
+          ${timeAgo ? `<span class="provider-time" title="${escapeHTML(connectedAt)}">${escapeHTML(timeAgo)}</span>` : ""}
+        </div>
+        <span class="provider-clip-count">${clipCount} clip${clipCount === 1 ? "" : "s"}</span>
+      </div>
+    `;
+  }).join("");
+}
+
+// ─── Rendering: Clip list (grouped by provider) ───
+
 function renderClipList(errorMessage = "") {
-  clipCount.textContent = `${state.clips.length} clip${state.clips.length === 1 ? "" : "s"}`;
+  const totalClips = state.clips.length;
+  clipCountEl.textContent = `${totalClips} clip${totalClips === 1 ? "" : "s"}`;
 
   if (errorMessage) {
     clipList.innerHTML = `<div class="notice">${escapeHTML(errorMessage)}</div>`;
     return;
   }
 
-  if (state.clips.length === 0) {
-    clipList.innerHTML = '<div class="empty-list">No clips registered.</div>';
+  if (totalClips === 0) {
+    clipList.innerHTML = '<div class="empty-list-sm">No clips registered.</div>';
     return;
+  }
+
+  // Filter by search
+  let filteredClips = state.clips;
+  if (state.searchQuery) {
+    filteredClips = state.clips.filter((c) =>
+      c.name.toLowerCase().includes(state.searchQuery) ||
+      (c.provider && c.provider.toLowerCase().includes(state.searchQuery)) ||
+      (c.package && c.package.toLowerCase().includes(state.searchQuery)) ||
+      (c.domain && c.domain.toLowerCase().includes(state.searchQuery))
+    );
+  }
+
+  if (filteredClips.length === 0) {
+    clipList.innerHTML = '<div class="empty-list-sm">No clips match your search.</div>';
+    return;
+  }
+
+  // Group by provider
+  const groups = new Map();
+  for (const clip of filteredClips) {
+    const provider = clip.provider || "unknown";
+    if (!groups.has(provider)) {
+      groups.set(provider, []);
+    }
+    groups.get(provider).push(clip);
   }
 
   clipList.innerHTML = "";
 
-  for (const clip of state.clips) {
-    const button = document.createElement("button");
-    button.type = "button";
-    button.className = `clip-item${clip.name === state.selectedClipName ? " active" : ""}`;
-    button.addEventListener("click", () => {
-      void selectClip(clip.name);
+  for (const [provider, clips] of groups) {
+    const groupEl = document.createElement("div");
+    groupEl.className = `clip-group${state.collapsedGroups[provider] ? " collapsed" : ""}`;
+
+    const headerBtn = document.createElement("button");
+    headerBtn.type = "button";
+    headerBtn.className = "clip-group-header";
+    headerBtn.innerHTML = `
+      <span class="clip-group-label" title="${escapeHTML(provider)}">${escapeHTML(provider)}</span>
+      <span class="clip-group-count">${clips.length}</span>
+      <span class="clip-group-chevron">&#9660;</span>
+    `;
+    headerBtn.addEventListener("click", () => {
+      state.collapsedGroups[provider] = !state.collapsedGroups[provider];
+      groupEl.classList.toggle("collapsed");
     });
 
-    const commandCount = getClipCommands(clip).length;
+    const itemsEl = document.createElement("div");
+    itemsEl.className = "clip-group-items";
 
-    button.innerHTML = `
-      <div class="clip-item-head">
-        <span class="clip-name">${escapeHTML(clip.name)}</span>
-        <span class="status-pill ${clipStateClass(clip)}">${clipStateLabel(clip)}</span>
-      </div>
-      <p class="clip-source">${escapeHTML(displayClipSource(clip))}</p>
-      <div class="clip-stats">
-        <span class="badge">${commandCount} command${commandCount === 1 ? "" : "s"}</span>
-        ${clip.tokenProtected ? '<span class="badge">token</span>' : ""}
-      </div>
-    `;
+    for (const clip of clips) {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = `clip-item${clip.name === state.selectedClipName ? " active" : ""}`;
+      btn.addEventListener("click", () => void selectClip(clip.name));
 
-    clipList.appendChild(button);
+      const commandCount = getClipCommands(clip).length;
+      const pkgInfo = clip.package && clip.package !== clip.name ? clip.package : "";
+      const versionInfo = clip.version ? `v${clip.version}` : "";
+      const metaParts = [pkgInfo, versionInfo].filter(Boolean).join(" ");
+
+      const webIcon = clip.hasWeb
+        ? '<svg class="clip-web-icon" width="12" height="12" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.5"/><path d="M2 8h12M8 2c-2 2-2 10 0 12M8 2c2 2 2 10 0 12" stroke="currentColor" stroke-width="1.2"/></svg>'
+        : "";
+
+      btn.innerHTML = `
+        <div class="clip-item-head">
+          <span class="clip-name">${escapeHTML(clip.name)}${webIcon}</span>
+          <span class="clip-cmd-count">${commandCount} cmd${commandCount === 1 ? "" : "s"}</span>
+        </div>
+        ${metaParts ? `<div class="clip-meta-row"><span class="clip-pkg">${escapeHTML(metaParts)}</span></div>` : ""}
+      `;
+
+      itemsEl.appendChild(btn);
+    }
+
+    groupEl.appendChild(headerBtn);
+    groupEl.appendChild(itemsEl);
+    clipList.appendChild(groupEl);
   }
 }
+
+// ─── Clip status ───
+
+function clipStatusInfo(clip) {
+  if (!state.connected) return { cls: "stopped", label: "hub offline" };
+  const provider = state.providers.find((p) => p.name === clip.provider);
+  if (!provider) return { cls: "stopped", label: "no provider" };
+  return { cls: "running", label: "available" };
+}
+
+// ─── Rendering: Detail panel ───
 
 function renderDetail(isLoading = false) {
   const clip = getSelectedClip();
   if (!clip) {
     detailView.innerHTML = `
       <div class="empty-state">
-        <h2>Select a clip</h2>
-        <p>Choose a clip from the list to inspect its manifest and run commands.</p>
+        <div class="empty-state-inner">
+          <div class="empty-icon">
+            <svg width="48" height="48" viewBox="0 0 48 48" fill="none"><rect x="8" y="10" width="32" height="28" rx="4" stroke="currentColor" stroke-width="2" opacity="0.3"/><path d="M16 22h16M16 28h10" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity="0.3"/></svg>
+          </div>
+          <h2>Select a clip</h2>
+          <p>Choose a clip from the list to inspect its manifest and run commands.</p>
+        </div>
       </div>
     `;
     return;
@@ -223,17 +856,19 @@ function renderDetail(isLoading = false) {
   const manifest = state.selectedManifest || clip.manifest || normalizeManifest(null, clip) || { name: clip.name, commands: [] };
   const commands = Array.isArray(manifest.commands) ? manifest.commands : [];
   const hasWeb = Boolean(manifest.hasWeb ?? clip.hasWeb);
+  const description = manifest.description || "";
+  const status = clipStatusInfo(clip);
 
   detailView.innerHTML = `
     <div class="detail-wrap">
       <div class="detail-header">
         <div class="detail-title">
           <h2>${escapeHTML(clip.name)}</h2>
-          <p class="detail-meta">Inspect manifest metadata and invoke clip commands through HubService.</p>
+          ${description ? `<p class="detail-desc">${escapeHTML(description)}</p>` : ""}
         </div>
         <div class="detail-actions">
-          ${hasWeb ? `<a class="secondary detail-link" href="${escapeHTML(clipWebURL(clip.name))}">Open Web UI</a>` : ""}
-          <span class="status-pill ${clipStateClass(clip)}">${clipStateLabel(clip)}</span>
+          ${hasWeb ? `<a class="detail-web-btn" href="${escapeHTML(clipWebURL(clip.name))}">Open Web UI</a>` : ""}
+          <span class="status-pill ${status.cls}">${escapeHTML(status.label)}</span>
         </div>
       </div>
 
@@ -257,48 +892,22 @@ function renderDetail(isLoading = false) {
       </div>
 
       ${isLoading ? '<div class="loading">Loading manifest...</div>' : ""}
-      ${state.detailError ? renderInlineNotice(state.detailError) : ""}
+      ${state.detailError ? `<div class="notice">${escapeHTML(state.detailError)}</div>` : ""}
 
-      <section>
-        <div class="command-header">
-          <div>
-            <h3>Commands</h3>
-            <p class="command-help">Click a command to open a JSON input form and run it.</p>
-          </div>
-        </div>
+      <section class="commands-section">
+        <h3>Commands</h3>
         <div class="commands">
-          ${commands.length === 0 ? '<div class="empty-list">No commands found in the manifest.</div>' : commands.map((command) => renderCommandCard(clip, command)).join("")}
+          ${commands.length === 0
+            ? '<div class="empty-list-sm">No commands found in the manifest.</div>'
+            : commands.map((cmd) => renderCommandCard(clip, cmd)).join("")}
         </div>
-      </section>
-
-      <section class="result-card">
-        <div class="result-header">
-          <span class="result-title">Execution Result</span>
-          <span class="result-meta">${renderResultMeta()}</span>
-        </div>
-        <pre class="result-output">${escapeHTML(renderResultBody())}</pre>
       </section>
     </div>
   `;
 
-  for (const commandObj of commands) {
-    const commandName = typeof commandObj === "string" ? commandObj : commandObj.name;
-
-    const toggle = document.querySelector(`[data-command-toggle="${cssEscape(commandName)}"]`);
-    if (toggle) {
-      toggle.addEventListener("click", () => {
-        state.expandedCommand = state.expandedCommand === commandName ? null : commandName;
-        renderDetail();
-      });
-    }
-
-    const runButton = document.querySelector(`[data-command-run="${cssEscape(commandName)}"]`);
-    if (runButton) {
-      runButton.addEventListener("click", () => {
-        void invokeCommand(commandName);
-      });
-    }
-  }
+  // Bind events
+  bindCommandEvents(clip, commands);
+  bindResultEvents();
 }
 
 function renderCommandCard(clip, commandObj) {
@@ -307,49 +916,183 @@ function renderCommandCard(clip, commandObj) {
   const running = state.runningCommand === commandName;
   const commandDescription = typeof commandObj === "object" ? String(commandObj.description || "").trim() : "";
 
-  let inputValue = getCommandInput(clip.name, commandName);
-  if (!inputValue) {
-    inputValue = "{}";
-    setCommandInput(clip.name, commandName, inputValue);
-  }
-
   return `
     <article class="command-card${expanded ? " expanded" : ""}">
       <button type="button" class="command-toggle" data-command-toggle="${escapeHTML(commandName)}">
-        <span class="command-name">${escapeHTML(commandName)}</span>
-        <span class="command-arrow">${expanded ? "Hide" : "Open"}</span>
+        <span>
+          <span class="command-name">${escapeHTML(commandName)}</span>
+          ${commandDescription ? `<span class="command-desc-inline">${escapeHTML(truncate(commandDescription, 60))}</span>` : ""}
+        </span>
+        <span class="command-arrow">${expanded ? "&#9662;" : "&#9656;"}</span>
       </button>
-      ${expanded ? `
-        <div class="command-body">
-          ${commandDescription ? `<p class="command-help">${escapeHTML(commandDescription)}</p>` : ""}
-          <label class="command-label" for="command-input-${escapeHTML(commandName)}">Input JSON</label>
-          <textarea
-            id="command-input-${escapeHTML(commandName)}"
-            class="command-input"
-            data-command-input="${escapeHTML(commandName)}"
-            spellcheck="false"
-            oninput="setCommandInput('${escapeHTML(clip.name)}', '${escapeHTML(commandName)}', this.value)"
-          >${escapeHTML(inputValue)}</textarea>
-          <div class="command-footer">
-            <p class="status-note">Requests are sent to <code>${escapeHTML(HUB_PROCEDURES.invoke)}</code>.</p>
-            <button type="button" class="run-button" data-command-run="${escapeHTML(commandName)}" ${running ? "disabled" : ""}>
-              ${running ? "Running..." : "Run command"}
-            </button>
-          </div>
-        </div>
-      ` : ""}
+      ${expanded ? renderCommandBody(clip, commandName, commandDescription, running) : ""}
     </article>
   `;
 }
 
-function renderResultMeta() {
-  if (!state.lastResult) {
-    return "No command executed yet";
+function renderCommandBody(clip, commandName, description, running) {
+  const formDef = SMART_FORMS[commandName];
+  const isNoInput = NO_INPUT_COMMANDS.has(commandName);
+
+  let formHTML = "";
+
+  if (formDef) {
+    // Smart form
+    const fieldsHTML = formDef.fields.map((field) => {
+      const value = getSmartInputValue(clip.name, commandName, field.name);
+      if (field.inputType === "select") {
+        const optionsHTML = field.options.map((opt) =>
+          `<option value="${escapeHTML(opt)}"${opt === value ? " selected" : ""}>${opt || "(default)"}</option>`
+        ).join("");
+        return `
+          <div class="form-field">
+            <label class="form-label">${escapeHTML(field.label)}</label>
+            <select class="form-select" data-smart-field="${escapeHTML(commandName)}:${escapeHTML(field.name)}">${optionsHTML}</select>
+          </div>
+        `;
+      }
+      if (field.inputType === "textarea") {
+        return `
+          <div class="form-field">
+            <label class="form-label">${escapeHTML(field.label)}</label>
+            <textarea class="form-textarea form-smart-textarea" data-smart-field="${escapeHTML(commandName)}:${escapeHTML(field.name)}" placeholder="${escapeHTML(field.placeholder || "")}">${escapeHTML(value)}</textarea>
+          </div>
+        `;
+      }
+      const inputType = field.inputType === "number" ? "number" : field.inputType === "date" ? "date" : "text";
+      return `
+        <div class="form-field">
+          <label class="form-label">${escapeHTML(field.label)}</label>
+          <input type="${inputType}" class="form-input" data-smart-field="${escapeHTML(commandName)}:${escapeHTML(field.name)}" value="${escapeHTML(value)}" placeholder="${escapeHTML(field.placeholder || "")}">
+        </div>
+      `;
+    }).join("");
+
+    formHTML = `<div class="form-row">${fieldsHTML}</div>`;
+  } else if (isNoInput) {
+    // No input needed
+    formHTML = '<p class="command-help-text">This command requires no input.</p>';
+  } else {
+    // JSON textarea fallback
+    let inputValue = getCommandInput(clip.name, commandName);
+    if (!inputValue) {
+      inputValue = "{}";
+      setCommandInput(clip.name, commandName, inputValue);
+    }
+    formHTML = `
+      <div class="form-field">
+        <label class="form-label">Input JSON</label>
+        <textarea
+          class="form-textarea"
+          data-command-input="${escapeHTML(commandName)}"
+          spellcheck="false"
+        >${escapeHTML(inputValue)}</textarea>
+      </div>
+    `;
   }
+
+  const inlineResult = (state.lastResult?.command === commandName && state.lastResult?.clip === clip.name)
+    ? renderResultSection()
+    : "";
+
+  return `
+    <div class="command-body">
+      ${description ? `<p class="command-help-text">${escapeHTML(description)}</p>` : ""}
+      ${formHTML}
+      <div class="command-footer">
+        <button type="button" class="run-button" data-command-run="${escapeHTML(commandName)}" ${running ? "disabled" : ""}>
+          ${running ? '<span class="spinner"></span> Running...' : "Run"}
+        </button>
+      </div>
+      ${inlineResult}
+    </div>
+  `;
+}
+
+function bindCommandEvents(clip, commands) {
+  for (const commandObj of commands) {
+    const commandName = typeof commandObj === "string" ? commandObj : commandObj.name;
+
+    const toggle = document.querySelector(`[data-command-toggle="${cssEscape(commandName)}"]`);
+    if (toggle) {
+      toggle.addEventListener("click", () => {
+        state.expandedCommand = state.expandedCommand === commandName ? null : commandName;
+        updateHash();
+        renderDetail();
+      });
+    }
+
+    const runBtn = document.querySelector(`[data-command-run="${cssEscape(commandName)}"]`);
+    if (runBtn) {
+      runBtn.addEventListener("click", () => void invokeCommand(commandName));
+    }
+
+    // Bind smart form inputs
+    const smartFields = document.querySelectorAll(`[data-smart-field^="${cssEscape(commandName)}:"]`);
+    for (const field of smartFields) {
+      const [, fieldName] = field.dataset.smartField.split(":");
+      field.addEventListener("input", (e) => {
+        setSmartInputValue(clip.name, commandName, fieldName, e.target.value);
+      });
+      field.addEventListener("change", (e) => {
+        setSmartInputValue(clip.name, commandName, fieldName, e.target.value);
+      });
+      // Enter key runs command
+      if (field.tagName === "INPUT") {
+        field.addEventListener("keydown", (e) => {
+          if (e.key === "Enter") void invokeCommand(commandName);
+        });
+      }
+    }
+
+    // Bind JSON textarea
+    const textarea = document.querySelector(`textarea[data-command-input="${cssEscape(commandName)}"]`);
+    if (textarea) {
+      textarea.addEventListener("input", (e) => {
+        setCommandInput(clip.name, commandName, e.target.value);
+      });
+    }
+  }
+}
+
+// ─── Rendering: Result section ───
+
+function renderResultSection() {
+  const result = state.lastResult;
+  const resultBody = renderResultBodyHTML();
+  const imagePreview = extractBase64Image(result?.payload);
+  const bodyText = renderResultBodyText();
+  const isLarge = bodyText.length > 1500;
+
+  return `
+    <section class="result-card">
+      <div class="result-header">
+        <span class="result-title">Result</span>
+        <span class="result-meta ${result ? (result.ok ? "ok" : "err") : ""}">${renderResultMeta()}</span>
+      </div>
+      ${imagePreview ? `<div class="result-image-preview"><img src="${imagePreview}" alt="Result image"></div>` : ""}
+      <pre class="result-output${isLarge && !state.resultExpanded ? " collapsed" : ""}">${resultBody}</pre>
+      ${isLarge ? `<button type="button" class="result-toggle" data-result-toggle>${state.resultExpanded ? "Collapse" : "Show all"}</button>` : ""}
+    </section>
+  `;
+}
+
+function bindResultEvents() {
+  const toggleBtn = document.querySelector("[data-result-toggle]");
+  if (toggleBtn) {
+    toggleBtn.addEventListener("click", () => {
+      state.resultExpanded = !state.resultExpanded;
+      renderDetail();
+    });
+  }
+}
+
+function renderResultMeta() {
+  if (!state.lastResult) return "No command executed yet";
   return `${state.lastResult.clip}/${state.lastResult.command} - ${state.lastResult.meta}`;
 }
 
-function renderResultBody() {
+function renderResultBodyText() {
   if (!state.lastResult) {
     return JSON.stringify({ status: "idle" }, null, 2);
   }
@@ -359,53 +1102,107 @@ function renderResultBody() {
   return JSON.stringify(state.lastResult.payload, null, 2);
 }
 
-function renderInlineNotice(message) {
-  return `<div class="notice">${escapeHTML(message)}</div>`;
+function renderResultBodyHTML() {
+  const text = renderResultBodyText();
+  // Try to syntax-highlight JSON
+  try {
+    const parsed = JSON.parse(text);
+    return syntaxHighlightJSON(parsed);
+  } catch {
+    return escapeHTML(text);
+  }
 }
+
+// ─── JSON syntax highlighting ───
+
+function syntaxHighlightJSON(value, indent = 0) {
+  const pad = "  ".repeat(indent);
+  const pad1 = "  ".repeat(indent + 1);
+
+  if (value === null) {
+    return `<span class="json-null">null</span>`;
+  }
+  if (typeof value === "boolean") {
+    return `<span class="json-bool">${value}</span>`;
+  }
+  if (typeof value === "number") {
+    return `<span class="json-number">${value}</span>`;
+  }
+  if (typeof value === "string") {
+    return `<span class="json-string">"${escapeHTML(value)}"</span>`;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return `<span class="json-bracket">[]</span>`;
+    const items = value.map((item) => `${pad1}${syntaxHighlightJSON(item, indent + 1)}`);
+    return `<span class="json-bracket">[</span>\n${items.join(",\n")}\n${pad}<span class="json-bracket">]</span>`;
+  }
+
+  if (typeof value === "object") {
+    const keys = Object.keys(value);
+    if (keys.length === 0) return `<span class="json-bracket">{}</span>`;
+    const entries = keys.map((key) => {
+      return `${pad1}<span class="json-key">"${escapeHTML(key)}"</span>: ${syntaxHighlightJSON(value[key], indent + 1)}`;
+    });
+    return `<span class="json-bracket">{</span>\n${entries.join(",\n")}\n${pad}<span class="json-bracket">}</span>`;
+  }
+
+  return escapeHTML(String(value));
+}
+
+// ─── Base64 image detection ───
+
+function extractBase64Image(payload) {
+  if (!payload || typeof payload !== "object") return null;
+
+  // Check common patterns for base64 image data
+  const candidates = [
+    payload.image, payload.data, payload.screenshot,
+    payload.imageData, payload.image_data, payload.base64,
+    payload.result?.image, payload.result?.data, payload.result?.screenshot,
+  ];
+
+  for (const val of candidates) {
+    if (typeof val === "string" && val.length > 100) {
+      // Check if it starts with a data URI
+      if (val.startsWith("data:image/")) return val;
+      // Check if it looks like raw base64 (PNG magic bytes in base64: iVBOR)
+      if (val.startsWith("iVBOR") || val.startsWith("/9j/") || val.startsWith("R0lGOD")) {
+        // PNG, JPEG, GIF
+        const prefix = val.startsWith("iVBOR") ? "data:image/png;base64," :
+                       val.startsWith("/9j/") ? "data:image/jpeg;base64," :
+                       "data:image/gif;base64,";
+        return prefix + val;
+      }
+    }
+  }
+
+  return null;
+}
+
+// ─── Notices ───
 
 function renderNotice(title, message) {
   return `
     <div class="empty-state">
-      <h2>${escapeHTML(title)}</h2>
-      <div class="notice">${escapeHTML(message)}</div>
+      <div class="empty-state-inner">
+        <h2>${escapeHTML(title)}</h2>
+        <div class="notice">${escapeHTML(message)}</div>
+      </div>
     </div>
   `;
 }
+
+// ─── Helpers ───
 
 function getSelectedClip() {
   return state.clips.find((clip) => clip.name === state.selectedClipName) || null;
 }
 
 function getClipCommands(clip) {
-  if (Array.isArray(clip?.manifest?.commands)) {
-    return clip.manifest.commands;
-  }
-  if (Array.isArray(clip?.commands)) {
-    return clip.commands;
-  }
+  if (Array.isArray(clip?.manifest?.commands)) return clip.manifest.commands;
+  if (Array.isArray(clip?.commands)) return clip.commands;
   return [];
-}
-
-function clipStateClass() {
-  return "running";
-}
-
-function clipStateLabel() {
-  return "available";
-}
-
-function displayClipSource(clip) {
-  const parts = [];
-  if (clip.provider) {
-    parts.push(clip.provider);
-  }
-  if (clip.package && clip.package !== clip.name) {
-    parts.push(clip.package);
-  }
-  if (clip.version) {
-    parts.push(`v${clip.version}`);
-  }
-  return parts.join(" / ") || "-";
 }
 
 function clipWebURL(name) {
@@ -414,15 +1211,105 @@ function clipWebURL(name) {
 
 function getCommandInput(clipName, commandName) {
   const key = `${clipName}:${commandName}`;
-  if (!(key in state.inputs)) {
-    state.inputs[key] = "{}";
-  }
+  if (!(key in state.inputs)) state.inputs[key] = "{}";
   return state.inputs[key];
 }
 
 function setCommandInput(clipName, commandName, value) {
   state.inputs[`${clipName}:${commandName}`] = value;
 }
+
+function truncate(text, max) {
+  if (text.length <= max) return text;
+  return text.slice(0, max - 1) + "\u2026";
+}
+
+function escapeHTML(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function cssEscape(value) {
+  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+    return CSS.escape(value);
+  }
+  return String(value).replace(/[^a-zA-Z0-9_-]/g, "\\$&");
+}
+
+// ─── Normalization ───
+
+function normalizeClipInfo(clip) {
+  const commands = Array.isArray(clip?.commands) ? clip.commands.map(normalizeCommandInfo).filter(Boolean) : [];
+  return {
+    name: String(clip?.name || "").trim(),
+    package: String(clip?.package || "").trim(),
+    version: String(clip?.version || "").trim(),
+    provider: String(clip?.provider || "").trim(),
+    domain: String(clip?.domain || "").trim(),
+    commands,
+    hasWeb: Boolean(clip?.hasWeb ?? clip?.has_web),
+    tokenProtected: Boolean(clip?.tokenProtected ?? clip?.token_protected),
+    dependencies: normalizeStringArray(clip?.dependencies),
+    manifest: clip?.manifest ? normalizeManifest(clip.manifest, clip) : null,
+  };
+}
+
+function normalizeManifest(manifest, fallback = null) {
+  if (!manifest && !fallback) return null;
+
+  const commandSource = Array.isArray(manifest?.commands)
+    ? manifest.commands
+    : Array.isArray(fallback?.commands)
+      ? fallback.commands
+      : [];
+
+  return {
+    name: String(manifest?.name || fallback?.name || "").trim(),
+    package: String(manifest?.package || fallback?.package || "").trim(),
+    version: String(manifest?.version || fallback?.version || "").trim(),
+    domain: String(manifest?.domain || fallback?.domain || "").trim(),
+    description: String(manifest?.description || "").trim(),
+    commands: commandSource.map(normalizeCommandInfo).filter(Boolean),
+    dependencies: normalizeStringArray(manifest?.dependencies || fallback?.dependencies),
+    hasWeb: Boolean(manifest?.hasWeb ?? manifest?.has_web ?? fallback?.hasWeb ?? fallback?.has_web),
+    patterns: normalizeStringArray(manifest?.patterns),
+  };
+}
+
+function normalizeCommandInfo(command) {
+  if (typeof command === "string") {
+    const name = command.trim();
+    return name ? { name, description: "", input: "", output: "" } : null;
+  }
+  if (!command) return null;
+  const name = String(command.name || "").trim();
+  if (!name) return null;
+  return {
+    name,
+    description: String(command.description || "").trim(),
+    input: String(command.input || "").trim(),
+    output: String(command.output || "").trim(),
+  };
+}
+
+function normalizeStringArray(values) {
+  if (!Array.isArray(values)) return [];
+  const result = [];
+  const seen = new Set();
+  for (const value of values) {
+    const text = String(value || "").trim();
+    if (!text || seen.has(text)) continue;
+    seen.add(text);
+    result.push(text);
+  }
+  return result.sort();
+}
+
+// ─── Connect-RPC transport (unchanged protocol logic) ───
 
 async function hubUnary(path, message) {
   const response = await fetch(path, {
@@ -471,9 +1358,7 @@ async function hubInvoke(clipName, commandName, input) {
 
 async function parseResponsePayload(response) {
   const text = await response.text();
-  if (!text) {
-    return null;
-  }
+  if (!text) return null;
   try {
     return JSON.parse(text);
   } catch {
@@ -504,18 +1389,14 @@ async function* readConnectStream(body) {
   try {
     for (;;) {
       const { value, done } = await reader.read();
-      if (done) {
-        break;
-      }
+      if (done) break;
       if (value && value.length > 0) {
         buffer = concatByteArrays(buffer, value);
       }
 
       for (;;) {
         const frame = readConnectFrame(buffer);
-        if (!frame) {
-          break;
-        }
+        if (!frame) break;
 
         buffer = frame.rest;
         if (frame.compressed) {
@@ -550,18 +1431,14 @@ async function* readConnectStream(body) {
 }
 
 function readConnectFrame(buffer) {
-  if (!(buffer instanceof Uint8Array) || buffer.length < 5) {
-    return null;
-  }
+  if (!(buffer instanceof Uint8Array) || buffer.length < 5) return null;
 
   const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
   const flags = view.getUint8(0);
   const length = view.getUint32(1);
   const totalLength = 5 + length;
 
-  if (buffer.length < totalLength) {
-    return null;
-  }
+  if (buffer.length < totalLength) return null;
 
   return {
     compressed: Boolean(flags & 0b00000001),
@@ -573,9 +1450,7 @@ function readConnectFrame(buffer) {
 
 function parseConnectJSON(bytes) {
   const text = textDecoder.decode(bytes);
-  if (!text) {
-    return {};
-  }
+  if (!text) return {};
   try {
     return JSON.parse(text);
   } catch (error) {
@@ -598,16 +1473,10 @@ function encodeProtoBytes(value) {
 }
 
 function decodeInvocationOutput(outputs) {
-  if (!outputs.length) {
-    return {};
-  }
-
+  if (!outputs.length) return {};
   const bytes = outputs.length === 1 ? outputs[0] : concatManyByteArrays(outputs);
   const text = textDecoder.decode(bytes);
-  if (!text.trim()) {
-    return {};
-  }
-
+  if (!text.trim()) return {};
   try {
     return JSON.parse(text);
   } catch {
@@ -616,12 +1485,8 @@ function decodeInvocationOutput(outputs) {
 }
 
 function concatByteArrays(left, right) {
-  if (!left.length) {
-    return right.slice();
-  }
-  if (!right.length) {
-    return left.slice();
-  }
+  if (!left.length) return right.slice();
+  if (!right.length) return left.slice();
   const combined = new Uint8Array(left.length + right.length);
   combined.set(left, 0);
   combined.set(right, left.length);
@@ -630,9 +1495,7 @@ function concatByteArrays(left, right) {
 
 function concatManyByteArrays(chunks) {
   let length = 0;
-  for (const chunk of chunks) {
-    length += chunk.length;
-  }
+  for (const chunk of chunks) length += chunk.length;
   const combined = new Uint8Array(length);
   let offset = 0;
   for (const chunk of chunks) {
@@ -659,99 +1522,4 @@ function decodeBase64Bytes(value) {
     bytes[i] = binary.charCodeAt(i);
   }
   return bytes;
-}
-
-function normalizeClipInfo(clip) {
-  const commands = Array.isArray(clip?.commands) ? clip.commands.map(normalizeCommandInfo).filter(Boolean) : [];
-  return {
-    name: String(clip?.name || "").trim(),
-    package: String(clip?.package || "").trim(),
-    version: String(clip?.version || "").trim(),
-    provider: String(clip?.provider || "").trim(),
-    domain: String(clip?.domain || "").trim(),
-    commands,
-    hasWeb: Boolean(clip?.hasWeb ?? clip?.has_web),
-    tokenProtected: Boolean(clip?.tokenProtected ?? clip?.token_protected),
-    dependencies: normalizeStringArray(clip?.dependencies),
-    manifest: clip?.manifest ? normalizeManifest(clip.manifest, clip) : null,
-  };
-}
-
-function normalizeManifest(manifest, fallback = null) {
-  if (!manifest && !fallback) {
-    return null;
-  }
-
-  const commandSource = Array.isArray(manifest?.commands)
-    ? manifest.commands
-    : Array.isArray(fallback?.commands)
-      ? fallback.commands
-      : [];
-
-  return {
-    name: String(manifest?.name || fallback?.name || "").trim(),
-    package: String(manifest?.package || fallback?.package || "").trim(),
-    version: String(manifest?.version || fallback?.version || "").trim(),
-    domain: String(manifest?.domain || fallback?.domain || "").trim(),
-    description: String(manifest?.description || "").trim(),
-    commands: commandSource.map(normalizeCommandInfo).filter(Boolean),
-    dependencies: normalizeStringArray(manifest?.dependencies || fallback?.dependencies),
-    hasWeb: Boolean(manifest?.hasWeb ?? manifest?.has_web ?? fallback?.hasWeb ?? fallback?.has_web),
-    patterns: normalizeStringArray(manifest?.patterns),
-  };
-}
-
-function normalizeCommandInfo(command) {
-  if (typeof command === "string") {
-    const name = command.trim();
-    return name ? { name, description: "", input: "", output: "" } : null;
-  }
-  if (!command) {
-    return null;
-  }
-
-  const name = String(command.name || "").trim();
-  if (!name) {
-    return null;
-  }
-
-  return {
-    name,
-    description: String(command.description || "").trim(),
-    input: String(command.input || "").trim(),
-    output: String(command.output || "").trim(),
-  };
-}
-
-function normalizeStringArray(values) {
-  if (!Array.isArray(values)) {
-    return [];
-  }
-  const result = [];
-  const seen = new Set();
-  for (const value of values) {
-    const text = String(value || "").trim();
-    if (!text || seen.has(text)) {
-      continue;
-    }
-    seen.add(text);
-    result.push(text);
-  }
-  return result.sort();
-}
-
-function escapeHTML(value) {
-  return String(value)
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
-}
-
-function cssEscape(value) {
-  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
-    return CSS.escape(value);
-  }
-  return String(value).replace(/[^a-zA-Z0-9_-]/g, "\\$&");
 }

--- a/web/index.html
+++ b/web/index.html
@@ -5,35 +5,98 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
   <title>Pinix Portal</title>
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E⚡%3C/text%3E%3C/svg%3E" type="image/svg+xml">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E%E2%9A%A1%3C/text%3E%3C/svg%3E" type="image/svg+xml">
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
   <div class="shell">
+    <!-- Compact header: one line -->
     <header class="topbar">
-      <div>
-        <p class="eyebrow">Pinix</p>
-        <h1>Pinix Portal</h1>
+      <div class="topbar-left">
+        <span class="logo-icon">P</span>
+        <span class="logo-text">Pinix Portal</span>
       </div>
-      <button id="refreshButton" class="primary" type="button">Refresh</button>
+      <div class="topbar-right">
+        <span id="hubAddress" class="topbar-stat"></span>
+        <span class="topbar-sep"></span>
+        <span id="providerCount" class="topbar-stat">0 providers</span>
+        <span class="topbar-sep"></span>
+        <span id="clipCount" class="topbar-stat">0 clips</span>
+        <span id="connectionBadge" class="connection-badge connected">Connected</span>
+      </div>
     </header>
 
+    <!-- Quick Actions bar -->
+    <div class="quick-actions" id="quickActions">
+      <button type="button" class="qa-btn" data-qa="screenshot">
+        <span class="qa-icon">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><rect x="2" y="3" width="12" height="10" rx="2" stroke="currentColor" stroke-width="1.5"/><circle cx="8" cy="8" r="2" stroke="currentColor" stroke-width="1.5"/></svg>
+        </span>
+        Screenshot
+      </button>
+      <button type="button" class="qa-btn" data-qa="speak-clipboard">
+        <span class="qa-icon">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M3 6v4l4 3V3L3 6z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/><path d="M10 5.5a3 3 0 010 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+        </span>
+        Speak Clipboard
+      </button>
+      <button type="button" class="qa-btn" data-qa="system-info">
+        <span class="qa-icon">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.5"/><path d="M8 5v3h2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </span>
+        System Info
+      </button>
+      <button type="button" class="qa-btn" data-qa="list-windows">
+        <span class="qa-icon">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><rect x="1.5" y="2.5" width="13" height="11" rx="2" stroke="currentColor" stroke-width="1.5"/><path d="M1.5 5.5h13" stroke="currentColor" stroke-width="1.5"/></svg>
+        </span>
+        List Windows
+      </button>
+    </div>
+
     <main class="layout">
+      <!-- Sidebar -->
       <aside class="sidebar-stack">
+        <!-- Provider panel -->
+        <section class="panel provider-panel" id="providerPanel">
+          <div class="panel-header-compact">
+            <h3>Providers</h3>
+            <button type="button" class="icon-btn" id="refreshProviders" title="Refresh providers" aria-label="Refresh providers">
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M2 8a6 6 0 0111.3-2.8M14 8a6 6 0 01-11.3 2.8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M13 2v3.2h-3.2M3 14v-3.2h3.2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </button>
+          </div>
+          <div id="providerList" class="provider-list">
+            <div class="empty-list-sm">No providers</div>
+          </div>
+        </section>
+
+        <!-- Clips panel -->
         <section class="panel sidebar-panel">
-          <div class="panel-header">
-            <h2>Clips</h2>
-            <p id="clipCount" class="panel-meta">0 clips</p>
+          <div class="panel-header-compact">
+            <h3>Clips</h3>
+            <button type="button" class="icon-btn" id="refreshButton" title="Refresh clips" aria-label="Refresh clips">
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M2 8a6 6 0 0111.3-2.8M14 8a6 6 0 01-11.3 2.8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M13 2v3.2h-3.2M3 14v-3.2h3.2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </button>
+          </div>
+          <!-- Search bar -->
+          <div class="search-wrap">
+            <svg class="search-icon" width="14" height="14" viewBox="0 0 16 16" fill="none"><circle cx="7" cy="7" r="4.5" stroke="currentColor" stroke-width="1.5"/><path d="M10.5 10.5L14 14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+            <input type="text" id="clipSearch" class="search-input" placeholder="Search clips... (Cmd+K)" autocomplete="off" spellcheck="false">
           </div>
           <div id="clipList" class="clip-list"></div>
         </section>
-
       </aside>
 
+      <!-- Detail panel -->
       <section class="panel detail">
         <div id="detailView" class="empty-state">
-          <h2>Select a clip</h2>
-          <p>Choose a clip from the list to inspect its manifest and run commands.</p>
+          <div class="empty-state-inner">
+            <div class="empty-icon">
+              <svg width="48" height="48" viewBox="0 0 48 48" fill="none"><rect x="8" y="10" width="32" height="28" rx="4" stroke="currentColor" stroke-width="2" opacity="0.3"/><path d="M16 22h16M16 28h10" stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity="0.3"/></svg>
+            </div>
+            <h2>Select a clip</h2>
+            <p>Choose a clip from the list to inspect its manifest and run commands.</p>
+          </div>
         </div>
       </section>
     </main>

--- a/web/style.css
+++ b/web/style.css
@@ -1,423 +1,774 @@
-/* style.css */
+/* style.css — Pinix Portal Redesign */
 
-/* Define OKLCH color variables for light mode */
+/* ─── Color tokens (light) ─── */
 :root {
-  --color-primary-base: oklch(50% 0.15 160); /* A tealish green */
-  --color-primary-dark: oklch(35% 0.15 160);
-  --color-primary-light: oklch(85% 0.05 160);
-  --color-primary-bg-subtle: oklch(95% 0.02 160);
+  --c-accent: oklch(50% 0.15 160);
+  --c-accent-dark: oklch(38% 0.15 160);
+  --c-accent-light: oklch(85% 0.05 160);
+  --c-accent-bg: oklch(95% 0.02 160);
 
-  --color-text-base: oklch(20% 0.02 240); /* Dark bluish-grey */
-  --color-text-muted: oklch(45% 0.02 240);
-  --color-text-inverted: oklch(98% 0.01 240);
+  --c-text: oklch(18% 0.02 240);
+  --c-text-2: oklch(42% 0.02 240);
+  --c-text-3: oklch(58% 0.02 240);
+  --c-text-inv: oklch(98% 0.005 240);
 
-  --color-background-body: oklch(98% 0.01 240);
-  --color-background-panel: oklch(100% 0 0 / 0.9);
-  --color-background-card: oklch(100% 0 0 / 0.62);
-  --color-background-card-hover: oklch(100% 0 0 / 0.88);
-  --color-background-card-active: oklch(90% 0.02 160 / 0.88);
-  --color-background-code: oklch(15% 0.02 240);
-  --color-background-input: oklch(95% 0.01 240 / 0.94);
-  --color-background-loading: oklch(100% 0 0 / 0.62);
+  --c-bg: oklch(97% 0.005 240);
+  --c-panel: oklch(100% 0 0 / 0.88);
+  --c-card: oklch(100% 0 0 / 0.55);
+  --c-card-hover: oklch(100% 0 0 / 0.82);
+  --c-card-active: oklch(92% 0.02 160 / 0.75);
+  --c-code-bg: oklch(14% 0.015 240);
+  --c-input-bg: oklch(95% 0.008 240 / 0.9);
+  --c-loading-bg: oklch(100% 0 0 / 0.55);
 
-  --color-border-panel: oklch(20% 0.02 240 / 0.14);
-  --color-border-card: oklch(20% 0.02 240 / 0.12);
-  --color-border-card-active: oklch(50% 0.15 160 / 0.4);
+  --c-border: oklch(20% 0.02 240 / 0.11);
+  --c-border-card: oklch(20% 0.02 240 / 0.09);
+  --c-border-active: oklch(50% 0.15 160 / 0.35);
 
-  --color-status-success: oklch(40% 0.12 140); /* Green */
-  --color-status-success-bg: oklch(40% 0.12 140 / 0.12);
-  --color-status-warning: oklch(60% 0.1 80); /* Orange */
-  --color-status-warning-bg: oklch(60% 0.1 80 / 0.12);
-  --color-status-error: oklch(50% 0.15 10); /* Red */
-  --color-status-error-bg: oklch(50% 0.15 10 / 0.12);
+  --c-ok: oklch(42% 0.12 145);
+  --c-ok-bg: oklch(42% 0.12 145 / 0.1);
+  --c-warn: oklch(58% 0.1 80);
+  --c-warn-bg: oklch(58% 0.1 80 / 0.1);
+  --c-err: oklch(50% 0.16 15);
+  --c-err-bg: oklch(50% 0.16 15 / 0.1);
 
-  --shadow-elevation-medium: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --shadow-elevation-large: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --shadow-sm: 0 1px 3px rgb(0 0 0 / 0.06), 0 1px 2px rgb(0 0 0 / 0.04);
+  --shadow-md: 0 4px 8px -2px rgb(0 0 0 / 0.08), 0 2px 4px -2px rgb(0 0 0 / 0.06);
+  --shadow-lg: 0 8px 16px -4px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.06);
 
-  --spacing-xxs: 4px;
-  --spacing-xs: 8px;
-  --spacing-sm: 12px;
-  --spacing-md: 16px;
-  --spacing-lg: 24px;
-  --spacing-xl: 32px;
-  --spacing-xxl: 48px;
+  --sp-1: 4px;
+  --sp-2: 8px;
+  --sp-3: 12px;
+  --sp-4: 16px;
+  --sp-5: 20px;
+  --sp-6: 24px;
+  --sp-8: 32px;
 
-  --radius-lg: 16px;
-  --radius-md: 10px;
-  --radius-sm: 6px;
+  --r-sm: 6px;
+  --r-md: 10px;
+  --r-lg: 14px;
+  --r-xl: 18px;
 
-  --font-family-body: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-  --font-family-heading: 'Lora', serif;
-  --font-family-mono: 'Fira Code', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  --f-sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --f-mono: ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+
+  --c-code-text: oklch(88% 0.02 200);
+
+  /* JSON syntax colors (light) */
+  --json-key: oklch(45% 0.15 250);
+  --json-string: oklch(42% 0.12 145);
+  --json-number: oklch(50% 0.16 15);
+  --json-bool: oklch(50% 0.14 300);
+  --json-null: oklch(55% 0.02 240);
+  --json-bracket: oklch(45% 0.02 240);
 }
 
-/* Dark mode overrides */
+/* ─── Dark mode ─── */
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-primary-base: oklch(60% 0.18 160);
-    --color-primary-dark: oklch(45% 0.18 160);
-    --color-primary-light: oklch(75% 0.08 160);
-    --color-primary-bg-subtle: oklch(15% 0.03 160);
+    --c-accent: oklch(62% 0.18 160);
+    --c-accent-dark: oklch(48% 0.18 160);
+    --c-accent-light: oklch(75% 0.08 160);
+    --c-accent-bg: oklch(14% 0.03 160);
 
-    --color-text-base: oklch(85% 0.02 240);
-    --color-text-muted: oklch(60% 0.02 240);
-    --color-text-inverted: oklch(10% 0.01 240);
+    --c-text: oklch(88% 0.015 240);
+    --c-text-2: oklch(62% 0.015 240);
+    --c-text-3: oklch(48% 0.015 240);
+    --c-text-inv: oklch(10% 0.005 240);
 
-    --color-background-body: oklch(10% 0.01 240);
-    --color-background-panel: oklch(12% 0.01 240 / 0.9);
-    --color-background-card: oklch(18% 0.01 240 / 0.62);
-    --color-background-card-hover: oklch(18% 0.01 240 / 0.88);
-    --color-background-card-active: oklch(25% 0.02 160 / 0.88);
-    --color-background-code: oklch(8% 0.01 240);
-    --color-background-input: oklch(15% 0.01 240 / 0.94);
-    --color-background-loading: oklch(18% 0.01 240 / 0.62);
+    --c-bg: oklch(9% 0.008 240);
+    --c-panel: oklch(13% 0.01 240 / 0.88);
+    --c-card: oklch(17% 0.01 240 / 0.55);
+    --c-card-hover: oklch(20% 0.01 240 / 0.82);
+    --c-card-active: oklch(22% 0.025 160 / 0.75);
+    --c-code-bg: oklch(7% 0.008 240);
+    --c-input-bg: oklch(14% 0.008 240 / 0.9);
+    --c-loading-bg: oklch(17% 0.01 240 / 0.55);
 
-    --color-border-panel: oklch(80% 0.02 240 / 0.14);
-    --color-border-card: oklch(80% 0.02 240 / 0.12);
-    --color-border-card-active: oklch(60% 0.18 160 / 0.4);
+    --c-border: oklch(80% 0.015 240 / 0.11);
+    --c-border-card: oklch(80% 0.015 240 / 0.09);
+    --c-border-active: oklch(62% 0.18 160 / 0.35);
 
-    --shadow-elevation-medium: 0 4px 6px -1px rgb(0 0 0 / 0.2), 0 2px 4px -2px rgb(0 0 0 / 0.2);
-    --shadow-elevation-large: 0 10px 15px -3px rgb(0 0 0 / 0.2), 0 4px 6px -4px rgb(0 0 0 / 0.2);
+    --shadow-sm: 0 1px 3px rgb(0 0 0 / 0.15), 0 1px 2px rgb(0 0 0 / 0.1);
+    --shadow-md: 0 4px 8px -2px rgb(0 0 0 / 0.2), 0 2px 4px -2px rgb(0 0 0 / 0.15);
+    --shadow-lg: 0 8px 16px -4px rgb(0 0 0 / 0.25), 0 4px 6px -4px rgb(0 0 0 / 0.15);
+
+    --c-code-text: oklch(88% 0.02 200);
+
+    --json-key: oklch(70% 0.12 250);
+    --json-string: oklch(68% 0.12 145);
+    --json-number: oklch(70% 0.14 30);
+    --json-bool: oklch(72% 0.12 300);
+    --json-null: oklch(55% 0.02 240);
+    --json-bracket: oklch(60% 0.02 240);
   }
 }
 
-/* Base styles */
-*, *::before, *::after {
-  box-sizing: border-box;
-}
-
-html, body {
-  margin: 0;
-  min-height: 100%;
-}
+/* ─── Reset ─── */
+*, *::before, *::after { box-sizing: border-box; }
+html, body { margin: 0; min-height: 100%; }
 
 body {
-  color: var(--color-text-base);
-  font-family: var(--font-family-body);
-  background: var(--color-background-body);
-  transition: background-color 0.3s ease;
+  color: var(--c-text);
+  font-family: var(--f-sans);
+  font-size: 14px;
+  line-height: 1.5;
+  background: var(--c-bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-button, input, textarea {
-  font: inherit;
-  color: inherit;
-}
+button, input, textarea, select { font: inherit; color: inherit; }
 
-/* Layout */
+/* ─── Shell ─── */
 .shell {
-  max-width: 1400px;
+  max-width: 1440px;
   margin: 0 auto;
-  padding: var(--spacing-xl);
+  padding: var(--sp-5);
 }
 
+/* ─── Topbar (one-line compact header) ─── */
 .topbar {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: space-between;
-  gap: var(--spacing-lg);
-  margin-bottom: var(--spacing-xl);
+  gap: var(--sp-4);
+  margin-bottom: var(--sp-4);
+  padding: var(--sp-2) 0;
 }
 
-.eyebrow {
-  margin: 0 0 var(--spacing-xs);
-  color: var(--color-primary-base);
-  font-size: 0.875rem;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+.topbar-left {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
 }
 
-.topbar h1,
-.panel-header h2,
-.detail-title h2,
-.empty-state h2 {
-  margin: 0;
-  font-family: var(--font-family-heading);
+.logo-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--r-sm);
+  background: linear-gradient(135deg, var(--c-accent), var(--c-accent-dark));
+  color: var(--c-text-inv);
   font-weight: 700;
+  font-size: 14px;
+  letter-spacing: -0.02em;
+  flex-shrink: 0;
+}
+
+.logo-text {
+  font-weight: 700;
+  font-size: 15px;
   letter-spacing: -0.02em;
 }
 
-.topbar h1 {
-  font-size: clamp(2.25rem, 4vw, 3.5rem);
-  line-height: 1.1;
+.topbar-right {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
 }
 
+.topbar-stat {
+  color: var(--c-text-2);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.topbar-sep {
+  width: 1px;
+  height: 14px;
+  background: var(--c-border);
+}
+
+.connection-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.connection-badge::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.connection-badge.connected {
+  color: var(--c-ok);
+  background: var(--c-ok-bg);
+}
+.connection-badge.connected::before {
+  background: var(--c-ok);
+}
+
+.connection-badge.disconnected {
+  color: var(--c-err);
+  background: var(--c-err-bg);
+}
+.connection-badge.disconnected::before {
+  background: var(--c-err);
+}
+
+/* ─── Quick Actions ─── */
+.quick-actions {
+  display: flex;
+  gap: var(--sp-2);
+  margin-bottom: var(--sp-4);
+  flex-wrap: wrap;
+}
+
+.qa-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border: 1px solid var(--c-border);
+  border-radius: 999px;
+  background: var(--c-card);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.qa-btn:hover {
+  background: var(--c-card-hover);
+  border-color: var(--c-accent);
+  color: var(--c-accent);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+}
+
+.qa-btn:active {
+  transform: translateY(0);
+}
+
+.qa-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.qa-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+/* ─── Layout ─── */
 .layout {
   display: grid;
-  grid-template-columns: minmax(300px, 400px) minmax(0, 1fr);
-  gap: var(--spacing-lg);
+  grid-template-columns: 300px minmax(0, 1fr);
+  gap: var(--sp-4);
+  align-items: start;
 }
 
 .sidebar-stack {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-lg);
+  gap: var(--sp-3);
+  position: sticky;
+  top: var(--sp-5);
+  max-height: calc(100vh - var(--sp-5) * 2);
+  overflow-y: auto;
 }
 
+/* ─── Panels ─── */
 .panel {
-  border: 1px solid var(--color-border-panel);
-  border-radius: var(--radius-lg);
-  background: var(--color-background-panel);
-  box-shadow: var(--shadow-elevation-large);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  transition: background-color 0.3s ease, border-color 0.3s ease;
-}
-
-.sidebar-panel {
+  border: 1px solid var(--c-border);
+  border-radius: var(--r-lg);
+  background: var(--c-panel);
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
   overflow: hidden;
 }
 
+.panel-header-compact {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--sp-3) var(--sp-4);
+  border-bottom: 1px solid var(--c-border);
+}
+
+.panel-header-compact h3 {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--c-text-2);
+}
+
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: none;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--c-text-3);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.icon-btn:hover {
+  background: var(--c-card-hover);
+  color: var(--c-text);
+}
+
+/* ─── Provider panel ─── */
+.provider-panel {
+  max-height: 200px;
+}
+
+.provider-list {
+  padding: var(--sp-2) var(--sp-3);
+  max-height: 140px;
+  overflow-y: auto;
+}
+
+.provider-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--sp-1) var(--sp-2);
+  border-radius: var(--r-sm);
+  font-size: 12px;
+}
+
+.provider-item + .provider-item {
+  margin-top: 2px;
+}
+
+.provider-name {
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 180px;
+}
+
+.provider-clip-count {
+  color: var(--c-text-3);
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+.provider-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--c-ok);
+  flex-shrink: 0;
+  margin-right: var(--sp-2);
+}
+
+.provider-item-left {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  overflow: hidden;
+}
+
+.provider-time {
+  color: var(--c-text-3);
+  font-size: 10px;
+  flex-shrink: 0;
+  margin-left: var(--sp-1);
+}
+
+/* ─── Search ─── */
+.search-wrap {
+  position: relative;
+  padding: var(--sp-2) var(--sp-3);
+  border-bottom: 1px solid var(--c-border);
+}
+
+.search-icon {
+  position: absolute;
+  left: calc(var(--sp-3) + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--c-text-3);
+  pointer-events: none;
+}
+
+.search-input {
+  width: 100%;
+  padding: 6px 8px 6px 28px;
+  border: 1px solid var(--c-border-card);
+  border-radius: var(--r-sm);
+  background: var(--c-input-bg);
+  font-size: 12px;
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.search-input:focus {
+  border-color: var(--c-accent);
+}
+
+.search-input::placeholder {
+  color: var(--c-text-3);
+}
+
+/* ─── Clip list ─── */
+.clip-list {
+  display: flex;
+  flex-direction: column;
+  padding: var(--sp-2);
+  gap: 1px;
+  max-height: calc(100vh - 380px);
+  overflow-y: auto;
+}
+
+/* Provider group in clip list */
+.clip-group {
+  margin-bottom: var(--sp-1);
+}
+
+.clip-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-2);
+  padding: var(--sp-1) var(--sp-2);
+  border: none;
+  border-radius: var(--r-sm);
+  background: transparent;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.12s ease;
+  user-select: none;
+}
+
+.clip-group-header:hover {
+  background: var(--c-card);
+}
+
+.clip-group-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--c-text-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.clip-group-count {
+  font-size: 10px;
+  color: var(--c-text-3);
+  flex-shrink: 0;
+}
+
+.clip-group-chevron {
+  color: var(--c-text-3);
+  font-size: 10px;
+  transition: transform 0.15s ease;
+  flex-shrink: 0;
+}
+
+.clip-group.collapsed .clip-group-chevron {
+  transform: rotate(-90deg);
+}
+
+.clip-group.collapsed .clip-group-items {
+  display: none;
+}
+
+.clip-group-items {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding-top: 2px;
+}
+
+/* Clip item */
+.clip-item {
+  width: 100%;
+  padding: var(--sp-2) var(--sp-3);
+  border: 1px solid transparent;
+  border-radius: var(--r-md);
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.12s ease;
+}
+
+.clip-item:hover {
+  background: var(--c-card);
+}
+
+.clip-item.active {
+  border-color: var(--c-border-active);
+  background: var(--c-card-active);
+}
+
+.clip-item-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-2);
+}
+
+.clip-name {
+  font-size: 13px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.clip-cmd-count {
+  color: var(--c-text-3);
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+.clip-meta-row {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  margin-top: 2px;
+}
+
+.clip-pkg {
+  color: var(--c-text-3);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Status pills and badges */
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.status-pill.running {
+  color: var(--c-ok);
+  background: var(--c-ok-bg);
+}
+
+.status-pill.stopped {
+  color: var(--c-warn);
+  background: var(--c-warn-bg);
+}
+
+.badge-sm {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 500;
+  background: var(--c-card);
+  color: var(--c-text-3);
+}
+
+/* ─── Detail panel ─── */
 .detail {
   min-height: 70vh;
 }
 
-.panel-header,
-.detail-wrap {
-  padding: var(--spacing-lg);
-}
-
-.panel-header {
+.empty-state {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: var(--spacing-md);
-  border-bottom: 1px solid var(--color-border-panel);
-  padding-bottom: var(--spacing-md);
-  margin-bottom: 0;
+  justify-content: center;
+  min-height: 50vh;
+  padding: var(--sp-6);
 }
 
-.panel-header h2 {
-  font-size: 1.5rem;
+.empty-state-inner {
+  text-align: center;
+  max-width: 300px;
 }
 
-.panel-meta,
-.detail-meta,
-.clip-source,
-.command-help,
-.status-note {
+.empty-icon {
+  color: var(--c-text-3);
+  margin-bottom: var(--sp-4);
+}
+
+.empty-state h2 {
+  margin: 0 0 var(--sp-2);
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.empty-state p {
   margin: 0;
-  color: var(--color-text-muted);
-  font-size: 0.925rem;
+  color: var(--c-text-2);
+  font-size: 13px;
 }
 
-.clip-list {
+/* Detail wrap */
+.detail-wrap {
+  padding: var(--sp-5);
   display: flex;
   flex-direction: column;
-  padding: var(--spacing-md);
-  gap: var(--spacing-sm);
+  gap: var(--sp-5);
 }
 
-.clip-item {
-  width: 100%;
-  padding: var(--spacing-md);
-  border: 1px solid var(--color-border-card);
-  border-radius: var(--radius-md);
-  background: var(--color-background-card);
-  text-align: left;
-  cursor: pointer;
-  transition: transform 0.15s ease, border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
-}
-
-.clip-item:hover,
-.clip-item:focus-visible {
-  border-color: var(--color-primary-base);
-  background: var(--color-background-card-hover);
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-elevation-medium);
-  outline: none;
-}
-
-.clip-item.active {
-  border-color: var(--color-border-card-active);
-  background: var(--color-background-card-active);
-  box-shadow: var(--shadow-elevation-medium);
-}
-
-.clip-item-head,
-.detail-header,
-.command-header,
-.result-header {
+.detail-header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: var(--spacing-sm);
+  gap: var(--sp-4);
+}
+
+.detail-title h2 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.detail-desc {
+  margin: var(--sp-1) 0 0;
+  color: var(--c-text-2);
+  font-size: 13px;
 }
 
 .detail-actions {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  gap: var(--spacing-sm);
-  flex-wrap: wrap;
-}
-
-.clip-item-head {
-  margin-bottom: var(--spacing-xs);
-}
-
-.clip-name {
-  font-size: 1.1rem;
-  font-weight: 600;
-}
-
-.clip-source {
-  font-size: 0.875rem;
-  line-height: 1.5;
-  word-break: break-word;
-  margin-top: var(--spacing-xs);
-}
-
-.clip-stats {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-xs);
-  flex-wrap: wrap;
-  margin-top: var(--spacing-xs);
-}
-
-.badge,
-.status-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-xxs);
-  padding: var(--spacing-xs) var(--spacing-sm);
-  border-radius: 999px;
-  font-size: 0.775rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.badge {
-  background: var(--color-text-base / 0.08);
-}
-
-.status-pill.running {
-  color: var(--color-status-success);
-  background: var(--color-status-success-bg);
-}
-
-.status-pill.stopped {
-  color: var(--color-status-warning);
-  background: var(--color-status-warning-bg);
-}
-
-.status-pill.online {
-  color: var(--color-status-success);
-  background: var(--color-status-success-bg);
-}
-
-.status-pill.offline {
-  color: var(--color-status-warning);
-  background: var(--color-status-warning-bg);
-}
-
-/* Buttons */
-.primary,
-.secondary,
-.run-button {
-  border: 0;
-  border-radius: 999px;
-  padding: var(--spacing-sm) var(--spacing-lg);
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 0.15s ease, opacity 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
-}
-
-.primary,
-.run-button {
-  color: var(--color-text-inverted);
-  background: linear-gradient(135deg, var(--color-primary-base), var(--color-primary-dark));
-  box-shadow: var(--shadow-elevation-medium);
-}
-
-.secondary {
-  color: var(--color-text-base);
-  background: var(--color-text-base / 0.08);
+  gap: var(--sp-2);
+  flex-shrink: 0;
 }
 
 .detail-link {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
+  gap: 4px;
+  padding: 5px 12px;
+  border: 1px solid var(--c-border);
+  border-radius: 999px;
+  background: transparent;
+  font-size: 12px;
+  font-weight: 500;
   text-decoration: none;
+  color: var(--c-text);
+  transition: all 0.12s ease;
 }
 
-.primary:hover,
-.run-button:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-elevation-large);
+.detail-link:hover {
+  border-color: var(--c-accent);
+  color: var(--c-accent);
 }
 
-.secondary:hover {
-  background: var(--color-text-base / 0.15);
-  transform: translateY(-1px);
-}
-
-.primary:disabled,
-.secondary:disabled,
-.run-button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-  transform: none;
-  box-shadow: none;
-}
-
-/* Detail view */
-.empty-state,
-.detail-wrap {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-xl);
-}
-
-.empty-state {
-  min-height: 70vh;
+.detail-web-btn {
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  padding: var(--spacing-lg);
-  text-align: center;
+  gap: 6px;
+  padding: 7px 18px;
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--c-accent), var(--c-accent-dark));
+  color: var(--c-text-inv);
+  font-size: 12px;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  box-shadow: var(--shadow-sm);
 }
 
+.detail-web-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+  color: var(--c-text-inv);
+}
+
+.clip-web-icon {
+  color: var(--c-accent);
+  flex-shrink: 0;
+  margin-left: var(--sp-1);
+}
+
+/* Meta grid */
 .detail-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: var(--spacing-md);
-}
-
-.meta-card,
-.result-card,
-.command-card {
-  border: 1px solid var(--color-border-card);
-  border-radius: var(--radius-md);
-  background: var(--color-background-card);
-  transition: background-color 0.3s ease, border-color 0.3s ease;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--sp-2);
 }
 
 .meta-card {
-  padding: var(--spacing-md);
+  padding: var(--sp-3);
+  border: 1px solid var(--c-border-card);
+  border-radius: var(--r-md);
+  background: var(--c-card);
 }
 
 .meta-label {
   display: block;
-  margin-bottom: var(--spacing-xs);
-  color: var(--color-text-muted);
-  font-size: 0.8rem;
+  margin-bottom: 2px;
+  color: var(--c-text-3);
+  font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.06em;
 }
 
 .meta-value {
-  word-break: break-word;
+  font-size: 13px;
   font-weight: 500;
+  word-break: break-word;
+}
+
+/* ─── Commands ─── */
+.commands-section h3 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--c-text-2);
 }
 
 .commands {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-sm);
+  gap: var(--sp-2);
+  margin-top: var(--sp-3);
+}
+
+.command-card {
+  border: 1px solid var(--c-border-card);
+  border-radius: var(--r-md);
+  background: var(--c-card);
+  overflow: hidden;
+  transition: all 0.15s ease;
+}
+
+.command-card.expanded {
+  border-color: var(--c-border-active);
+  background: var(--c-card-active);
 }
 
 .command-toggle {
@@ -425,220 +776,390 @@ button, input, textarea {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--spacing-md);
-  padding: var(--spacing-md);
-  border: 0;
-  border-radius: var(--radius-md);
+  gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
+  border: none;
   background: transparent;
   text-align: left;
   cursor: pointer;
-  transition: background 0.15s ease;
-}
-
-.command-card.expanded {
-  background: var(--color-background-card-active);
+  transition: background 0.12s ease;
 }
 
 .command-toggle:hover {
-  background: var(--color-background-card-hover);
+  background: var(--c-card-hover);
 }
 
 .command-name {
   font-weight: 600;
-  font-size: 1.05rem;
+  font-size: 13px;
+}
+
+.command-desc-inline {
+  color: var(--c-text-3);
+  font-size: 12px;
+  margin-left: var(--sp-2);
+  font-weight: 400;
 }
 
 .command-arrow {
-  color: var(--color-text-muted);
-  font-size: 0.9rem;
+  color: var(--c-text-3);
+  font-size: 11px;
   transition: transform 0.15s ease;
+  flex-shrink: 0;
 }
 
 .command-card.expanded .command-arrow {
   transform: rotate(90deg);
 }
 
+/* Command body (smart forms) */
 .command-body {
-  padding: 0 var(--spacing-md) var(--spacing-md);
+  padding: 0 var(--sp-4) var(--sp-4);
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-md);
+  gap: var(--sp-3);
 }
 
-.command-label {
-  font-size: 0.95rem;
+.command-help-text {
+  color: var(--c-text-2);
+  font-size: 12px;
+  margin: 0;
+}
+
+/* Smart form fields */
+.form-row {
+  display: flex;
+  gap: var(--sp-2);
+  align-items: flex-end;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+}
+
+.form-label {
+  font-size: 11px;
   font-weight: 600;
+  color: var(--c-text-2);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
-.command-input {
-  min-height: 180px;
-  padding: var(--spacing-md);
-  border: 1px solid var(--color-border-card);
-  border-radius: var(--radius-sm);
-  background: var(--color-background-input);
+.form-input,
+.form-select {
+  padding: 7px 10px;
+  border: 1px solid var(--c-border-card);
+  border-radius: var(--r-sm);
+  background: var(--c-input-bg);
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.form-input:focus,
+.form-select:focus {
+  border-color: var(--c-accent);
+}
+
+.form-textarea {
+  min-height: 100px;
+  padding: var(--sp-3);
+  border: 1px solid var(--c-border-card);
+  border-radius: var(--r-sm);
+  background: var(--c-input-bg);
+  font-family: var(--f-mono);
+  font-size: 12px;
+  line-height: 1.5;
   resize: vertical;
-  font-family: var(--font-family-mono);
-  font-size: 0.9rem;
+  outline: none;
+  transition: border-color 0.15s ease;
 }
 
-.command-input:focus-visible {
-  border-color: var(--color-primary-base);
-  outline: 2px solid var(--color-primary-base / 0.15);
+.form-textarea:focus {
+  border-color: var(--c-accent);
+}
+
+.form-smart-textarea {
+  min-height: 60px;
+  font-family: var(--f-sans);
+  font-size: 13px;
+}
+
+.form-row:has(.form-smart-textarea),
+.form-row:has(.form-textarea) {
+  flex-direction: column;
+}
+
+input[type="number"].form-input {
+  max-width: 120px;
+}
+
+input[type="date"].form-input {
+  max-width: 180px;
 }
 
 .command-footer {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: var(--spacing-md);
-  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--sp-3);
 }
 
+/* Run button */
+.run-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 18px;
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--c-accent), var(--c-accent-dark));
+  color: var(--c-text-inv);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  box-shadow: var(--shadow-sm);
+}
+
+.run-button:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+
+.run-button:active {
+  transform: translateY(0);
+}
+
+.run-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.run-button-sm {
+  padding: 6px 14px;
+  font-size: 12px;
+}
+
+/* ─── Result card ─── */
 .result-card {
+  border: 1px solid var(--c-border-card);
+  border-radius: var(--r-md);
+  background: var(--c-card);
   overflow: hidden;
 }
 
 .result-header {
-  padding: var(--spacing-md) var(--spacing-md);
-  border-bottom: 1px solid var(--color-border-panel);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--sp-3) var(--sp-4);
+  border-bottom: 1px solid var(--c-border);
+  gap: var(--sp-3);
 }
 
 .result-title {
+  font-size: 12px;
   font-weight: 600;
-  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--c-text-2);
 }
 
 .result-meta {
-  color: var(--color-text-muted);
-  font-size: 0.875rem;
+  color: var(--c-text-3);
+  font-size: 11px;
+  text-align: right;
+}
+
+.result-meta.ok {
+  color: var(--c-ok);
+}
+
+.result-meta.err {
+  color: var(--c-err);
 }
 
 .result-output {
   margin: 0;
-  padding: var(--spacing-md);
+  padding: var(--sp-4);
   overflow: auto;
-  color: oklch(90% 0.05 200); /* Light greyish-blue for code */
-  background: var(--color-background-code);
-  font-family: var(--font-family-mono);
-  font-size: 0.875rem;
+  max-height: 500px;
+  background: var(--c-code-bg);
+  font-family: var(--f-mono);
+  font-size: 12px;
   line-height: 1.6;
+  color: var(--c-code-text);
 }
 
-/* Utility classes for notices and loading */
-.notice {
-  padding: var(--spacing-sm) var(--spacing-md);
-  border-radius: var(--radius-sm);
-  background: var(--color-status-error-bg);
-  color: var(--color-status-error);
-  font-size: 0.9rem;
-  font-weight: 500;
+.result-output.collapsed {
+  max-height: 200px;
+  position: relative;
 }
 
-.loading,
-.empty-list {
-  padding: var(--spacing-md);
-  border-radius: var(--radius-md);
-  background: var(--color-background-loading);
-  color: var(--color-text-muted);
-  font-size: 0.95rem;
+.result-output.collapsed::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 60px;
+  background: linear-gradient(to bottom, transparent, var(--c-code-bg));
+  pointer-events: none;
+}
+
+.result-toggle {
+  display: block;
+  width: 100%;
+  padding: var(--sp-2);
+  border: none;
+  background: var(--c-code-bg);
+  color: var(--c-accent);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: center;
+  transition: opacity 0.12s ease;
+  border-top: 1px solid var(--c-border);
+}
+
+.result-toggle:hover {
+  opacity: 0.8;
+}
+
+/* Result image preview */
+.result-image-preview {
+  padding: var(--sp-4);
+  background: var(--c-code-bg);
   text-align: center;
 }
 
-/* Responsive adjustments */
-@media (max-width: 1024px) {
-  .shell {
-    padding: var(--spacing-lg);
-  }
+.result-image-preview img {
+  max-width: 100%;
+  max-height: 400px;
+  border-radius: var(--r-sm);
+  box-shadow: var(--shadow-md);
+}
 
+/* JSON syntax highlighting */
+.json-key { color: var(--json-key); }
+.json-string { color: var(--json-string); }
+.json-number { color: var(--json-number); }
+.json-bool { color: var(--json-bool); }
+.json-null { color: var(--json-null); }
+.json-bracket { color: var(--json-bracket); }
+
+/* ─── Notices & loading ─── */
+.notice {
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--r-sm);
+  background: var(--c-err-bg);
+  color: var(--c-err);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.loading {
+  padding: var(--sp-3);
+  color: var(--c-text-3);
+  font-size: 12px;
+  text-align: center;
+}
+
+.empty-list-sm {
+  padding: var(--sp-2) var(--sp-3);
+  color: var(--c-text-3);
+  font-size: 12px;
+  text-align: center;
+}
+
+/* ─── Spinner ─── */
+.spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--c-text-inv);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ─── Responsive ─── */
+@media (max-width: 900px) {
   .layout {
     grid-template-columns: 1fr;
   }
 
   .sidebar-stack {
-    gap: var(--spacing-lg);
+    position: static;
   }
 
   .detail {
     min-height: auto;
   }
 
-  .detail-grid {
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  }
-
-  .empty-state {
-    min-height: 50vh;
-  }
-}
-
-@media (max-width: 768px) {
-  .topbar {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .topbar h1 {
-    font-size: 2.5rem;
-  }
-
-  .panel-header,
-  .detail-wrap {
-    padding: var(--spacing-md);
-  }
-
-  .panel-header h2 {
-    font-size: 1.3rem;
-  }
-
   .clip-list {
-    padding: var(--spacing-md);
-  }
-
-  .clip-item,
-  .command-toggle,
-  .command-body,
-  .result-header,
-  .result-output,
-  .meta-card {
-    padding: var(--spacing-md);
-  }
-
-  .clip-item-head {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: var(--spacing-xs);
+    max-height: 300px;
   }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 600px) {
   .shell {
-    padding: var(--spacing-md);
+    padding: var(--sp-3);
   }
 
-  .topbar h1 {
-    font-size: 2rem;
+  .topbar {
+    flex-wrap: wrap;
+    gap: var(--sp-2);
   }
 
-  .layout {
-    gap: var(--spacing-md);
+  .quick-actions {
+    gap: var(--sp-1);
   }
 
-  .sidebar-stack {
-    gap: var(--spacing-md);
+  .qa-btn {
+    padding: 5px 10px;
+    font-size: 11px;
+  }
+
+  .detail-header {
+    flex-direction: column;
   }
 
   .detail-grid {
-    grid-template-columns: 1fr;
-    gap: var(--spacing-sm);
+    grid-template-columns: 1fr 1fr;
   }
 
-  .badge, .status-pill {
-    padding: var(--spacing-xxs) var(--spacing-sm);
-    font-size: 0.7rem;
+  .form-row {
+    flex-direction: column;
   }
+}
 
-  .primary, .secondary, .run-button {
-    padding: var(--spacing-sm) var(--spacing-md);
-    font-size: 0.9rem;
-  }
+/* ─── Scrollbar styling ─── */
+.clip-list::-webkit-scrollbar,
+.provider-list::-webkit-scrollbar,
+.result-output::-webkit-scrollbar {
+  width: 4px;
+}
+
+.clip-list::-webkit-scrollbar-track,
+.provider-list::-webkit-scrollbar-track,
+.result-output::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.clip-list::-webkit-scrollbar-thumb,
+.provider-list::-webkit-scrollbar-thumb,
+.result-output::-webkit-scrollbar-thumb {
+  background: var(--c-border);
+  border-radius: 2px;
 }


### PR DESCRIPTION
## Summary
- Portal 从"开发者调试工具"升级为"Hub 控制台"
- 三方 UX 方案融合（Claude + Gemini 3.1 Pro + Codex GPT-5.4），两轮迭代

## Changes
- Compact header + connection status badge
- Clip list grouped by Provider (collapsible)
- Search bar (Cmd+K)
- Smart command forms (speak, exec, search etc.) + no-input commands
- Quick Actions toolbar
- Provider panel with connection time
- Inline results per command
- URL hash routing for state persistence
- Keyboard navigation (Arrow keys)
- JSON syntax highlighting
- Auto-refresh (30s)
- Dark mode fixes
- System font stack

## Test plan
- [x] API proxy tested: 20 clips + 2 providers
- [x] JS syntax check passed (node -c)
- [x] Round 1 + Round 2 bug fixes applied
- [x] Claude UX review: 18/18 spec items addressed

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)