### PR TITLE
fix: route GetClipWeb through Hub → Provider

### DIFF
--- a/internal/daemon/connect.go
+++ b/internal/daemon/connect.go
@@ -118,26 +118,24 @@ func (h *HubService) GetClipWeb(ctx context.Context, req *connect.Request[pinixv
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("clip_name is required"))
 	}
 
+	if h.daemon == nil || h.daemon.provider == nil || !h.daemon.provider.HasClip(clipName) {
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("clip %q not found", clipName))
+	}
+
 	options := clipWebReadOptions{
 		Offset:      req.Msg.GetOffset(),
 		Length:      req.Msg.GetLength(),
 		IfNoneMatch: req.Msg.GetIfNoneMatch(),
 	}
-	if result, err := h.readLocalClipWebFile(clipName, req.Msg.GetPath(), options); err == nil {
-		return connect.NewResponse(clipWebResultToProto(result)), nil
-	} else if !isDaemonCode(err, "not_found") {
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	result, err := h.readProviderClipWebFile(ctx, clipName, req.Msg.GetPath(), options)
+	if err != nil {
 		return nil, connectErrorFromErr(err)
 	}
-
-	if h.daemon != nil && h.daemon.provider != nil && h.daemon.provider.HasClip(clipName) {
-		result, err := h.readProviderClipWebFile(ctx, clipName, req.Msg.GetPath(), options)
-		if err != nil {
-			return nil, connectErrorFromErr(err)
-		}
-		return connect.NewResponse(clipWebResultToProto(result)), nil
-	}
-
-	return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("clip %q not found", clipName))
+	return connect.NewResponse(clipWebResultToProto(result)), nil
 }
 
 func clipWebResultToProto(result *clipWebReadResult) *pinixv2.GetClipWebResponse {
@@ -376,20 +374,6 @@ func (h *HubService) localClipNames() ([]string, error) {
 	}
 	sort.Strings(result)
 	return result, nil
-}
-
-func (h *HubService) readLocalClipWebFile(clipName, requestedPath string, opts clipWebReadOptions) (*clipWebReadResult, error) {
-	if h.daemon == nil || !h.daemon.hasLocalRuntime() {
-		return nil, daemonError{Code: "not_found", Message: fmt.Sprintf("clip %q not found", clipName)}
-	}
-	clip, found, err := h.daemon.registry.GetClip(clipName)
-	if err != nil {
-		return nil, daemonError{Code: "internal", Message: fmt.Sprintf("load clip %q: %v", clipName, err)}
-	}
-	if !found {
-		return nil, daemonError{Code: "not_found", Message: fmt.Sprintf("clip %q not found", clipName)}
-	}
-	return readClipWebFile(clipWebDir(clip), requestedPath, opts)
 }
 
 func (h *HubService) readProviderClipWebFile(ctx context.Context, clipName, requestedPath string, opts clipWebReadOptions) (*clipWebReadResult, error) {

--- a/internal/daemon/http_test.go
+++ b/internal/daemon/http_test.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -48,26 +47,41 @@ func (s *stubProviderStream) Send(message *pinixv2.HubMessage) error {
 	return nil
 }
 
-func TestServeClipWebFileLocalSupportsRangeAndIfNoneMatch(t *testing.T) {
+func TestServeClipWebFileProviderLocalSupportsRangeAndIfNoneMatch(t *testing.T) {
 	registry := newTestRegistry(t)
-	clipDir := t.TempDir()
-	content := []byte("body { color: red; }\n")
-	if err := os.MkdirAll(filepath.Join(clipDir, "web"), 0o755); err != nil {
-		t.Fatalf("mkdir web: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(clipDir, "web", "style.css"), content, 0o644); err != nil {
-		t.Fatalf("write style.css: %v", err)
-	}
-	if err := registry.PutClip(ClipConfig{Name: "todo-web", Path: clipDir}); err != nil {
-		t.Fatalf("put clip: %v", err)
-	}
-
-	daemon := &Daemon{registry: registry, process: &ProcessManager{}, provider: NewProviderManager(registry)}
+	daemon := &Daemon{registry: registry, provider: NewProviderManager(nil)}
+	stream := startTestProviderSession(t, daemon.provider, "local-runtime", "todo-web")
 	handler := daemon.httpMux()
 
-	rangeResp := performRequest(handler, httptest.NewRequest(http.MethodGet, "/clips/todo-web/style.css", nil), func(req *http.Request) {
+	content := []byte("body { color: red; }\n")
+	etag := makeETag(content)
+
+	// Range request
+	rangeCh := performRequestAsync(handler, httptest.NewRequest(http.MethodGet, "/clips/todo-web/style.css", nil), func(req *http.Request) {
 		req.Header.Set("Range", "bytes=5-10")
 	})
+
+	message := waitHubMessage(t, stream.outgoing)
+	command := message.GetGetClipWebCommand()
+	if command == nil {
+		t.Fatalf("expected get_clip_web_command, got %#v", message.GetPayload())
+	}
+	if command.GetClipName() != "todo-web" {
+		t.Fatalf("clip name = %q, want %q", command.GetClipName(), "todo-web")
+	}
+	if command.GetOffset() != 5 || command.GetLength() != 6 {
+		t.Fatalf("range = (%d, %d), want (5, 6)", command.GetOffset(), command.GetLength())
+	}
+
+	stream.incoming <- &pinixv2.ProviderMessage{Payload: &pinixv2.ProviderMessage_GetClipWebResult{GetClipWebResult: &pinixv2.GetClipWebResult{
+		RequestId:   command.GetRequestId(),
+		Content:     content[5:11],
+		ContentType: "text/css; charset=utf-8",
+		Etag:        etag,
+		TotalSize:   int64(len(content)),
+	}}}
+
+	rangeResp := waitHTTPResponse(t, rangeCh)
 	if rangeResp.status != http.StatusPartialContent {
 		t.Fatalf("range status = %d, want %d", rangeResp.status, http.StatusPartialContent)
 	}
@@ -80,17 +94,33 @@ func TestServeClipWebFileLocalSupportsRangeAndIfNoneMatch(t *testing.T) {
 	if got, want := rangeResp.header.Get("Content-Range"), "bytes 5-10/21"; got != want {
 		t.Fatalf("content-range = %q, want %q", got, want)
 	}
-	etag := rangeResp.header.Get("ETag")
-	if got, want := etag, makeETag(content); got != want {
-		t.Fatalf("etag = %q, want %q", got, want)
+	if got := rangeResp.header.Get("ETag"); got != etag {
+		t.Fatalf("etag = %q, want %q", got, etag)
 	}
 	if got := rangeResp.header.Get("Content-Type"); got == "" {
 		t.Fatalf("content-type is empty")
 	}
 
-	cacheResp := performRequest(handler, httptest.NewRequest(http.MethodGet, "/clips/todo-web/style.css", nil), func(req *http.Request) {
+	// If-None-Match request
+	cacheCh := performRequestAsync(handler, httptest.NewRequest(http.MethodGet, "/clips/todo-web/style.css", nil), func(req *http.Request) {
 		req.Header.Set("If-None-Match", etag)
 	})
+
+	message = waitHubMessage(t, stream.outgoing)
+	command = message.GetGetClipWebCommand()
+	if command == nil {
+		t.Fatalf("expected cache get_clip_web_command, got %#v", message.GetPayload())
+	}
+
+	stream.incoming <- &pinixv2.ProviderMessage{Payload: &pinixv2.ProviderMessage_GetClipWebResult{GetClipWebResult: &pinixv2.GetClipWebResult{
+		RequestId:   command.GetRequestId(),
+		ContentType: "text/css; charset=utf-8",
+		Etag:        etag,
+		TotalSize:   int64(len(content)),
+		NotModified: true,
+	}}}
+
+	cacheResp := waitHTTPResponse(t, cacheCh)
 	if cacheResp.status != http.StatusNotModified {
 		t.Fatalf("cache status = %d, want %d", cacheResp.status, http.StatusNotModified)
 	}

--- a/internal/daemon/runtime_hub.go
+++ b/internal/daemon/runtime_hub.go
@@ -274,6 +274,8 @@ func (c *runtimeHubConnector) runProviderSession(parent context.Context) error {
 		switch {
 		case message.GetInvokeCommand() != nil:
 			go c.handleInvokeCommand(sessionCtx, stream, message.GetInvokeCommand())
+		case message.GetGetClipWebCommand() != nil:
+			go c.handleGetClipWebCommand(stream, message.GetGetClipWebCommand())
 		case message.GetPong() != nil:
 			continue
 		default:
@@ -505,6 +507,52 @@ func (c *runtimeHubConnector) handleInvokeCommand(ctx context.Context, stream *c
 			return
 		}
 	}
+}
+
+func (c *runtimeHubConnector) handleGetClipWebCommand(stream *connect.BidiStreamForClient[pinixv2.ProviderMessage, pinixv2.HubMessage], command *pinixv2.GetClipWebCommand) {
+	requestID := strings.TrimSpace(command.GetRequestId())
+	if requestID == "" {
+		return
+	}
+
+	clipName := strings.TrimSpace(command.GetClipName())
+	if clipName == "" {
+		_ = c.sendClipWebResult(stream, &pinixv2.GetClipWebResult{RequestId: requestID, Error: &pinixv2.HubError{Code: "invalid_argument", Message: "clip_name is required"}})
+		return
+	}
+
+	clip, ok, err := c.daemon.registry.GetClip(clipName)
+	if err != nil {
+		_ = c.sendClipWebResult(stream, &pinixv2.GetClipWebResult{RequestId: requestID, Error: &pinixv2.HubError{Code: "internal", Message: fmt.Sprintf("load clip %q: %v", clipName, err)}})
+		return
+	}
+	if !ok {
+		_ = c.sendClipWebResult(stream, &pinixv2.GetClipWebResult{RequestId: requestID, Error: &pinixv2.HubError{Code: "not_found", Message: fmt.Sprintf("clip %q not found", clipName)}})
+		return
+	}
+
+	result, err := readClipWebFile(clipWebDir(clip), command.GetPath(), clipWebReadOptions{
+		Offset:      command.GetOffset(),
+		Length:      command.GetLength(),
+		IfNoneMatch: command.GetIfNoneMatch(),
+	})
+	if err != nil {
+		_ = c.sendClipWebResult(stream, &pinixv2.GetClipWebResult{RequestId: requestID, Error: invokeErrorToHubError(err)})
+		return
+	}
+
+	_ = c.sendClipWebResult(stream, &pinixv2.GetClipWebResult{
+		RequestId:   requestID,
+		Content:     cloneBytes(result.Content),
+		ContentType: result.ContentType,
+		Etag:        result.ETag,
+		TotalSize:   result.TotalSize,
+		NotModified: result.NotModified,
+	})
+}
+
+func (c *runtimeHubConnector) sendClipWebResult(stream *connect.BidiStreamForClient[pinixv2.ProviderMessage, pinixv2.HubMessage], result *pinixv2.GetClipWebResult) error {
+	return c.sendProvider(stream, &pinixv2.ProviderMessage{Payload: &pinixv2.ProviderMessage_GetClipWebResult{GetClipWebResult: result}})
 }
 
 func (c *runtimeHubConnector) handleInstallCommand(ctx context.Context, stream *connect.BidiStreamForClient[pinixv2.RuntimeMessage, pinixv2.HubRuntimeMessage], command *pinixv2.InstallCommand) {


### PR DESCRIPTION
## Summary

- Runtime (as Provider) now handles `GetClipWebCommand` — reads web files from disk and returns via ProviderStream
- `GetClipWeb` removes `readLocalClipWebFile` shortcut, routes exclusively through Provider (with 10s timeout)
- Consistent with how `Invoke` works: Hub routes, Provider executes

Fixes #48

## Changes

| File | What |
|---|---|
| `runtime_hub.go` | Add `handleGetClipWebCommand` + `sendClipWebResult` — Runtime handles web file reads as Provider |
| `connect.go` | Remove `readLocalClipWebFile`, simplify `GetClipWeb` to Provider-only routing with timeout |
| `http_test.go` | Update test to use Provider path |

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/daemon/...`
- [x] Manual: `pinixd --port 9008`, `pinix add clip-todo --alias todo-web`, `curl /clips/todo-web/` → 200
- [x] Manual: `curl /clips/todo-web/app.js` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)