### PR TITLE
fix: route clip web invoke through Hub instead of d.process

### DIFF
--- a/internal/daemon/connect.go
+++ b/internal/daemon/connect.go
@@ -418,6 +418,133 @@ func isDaemonCode(err error, code string) bool {
 	return false
 }
 
+// invokeCollect routes an invoke through the Hub (local Runtime or Provider)
+// and collects all output chunks into a single aggregated JSON result.
+// Used by handleClipWebInvoke for non-streaming HTTP responses.
+func (h *HubService) invokeCollect(ctx context.Context, clipName, command string, input []byte) (json.RawMessage, error) {
+	clipName = strings.TrimSpace(clipName)
+	command = strings.TrimSpace(command)
+	if clipName == "" {
+		return nil, daemonError{Code: "invalid_argument", Message: "clip_name is required"}
+	}
+	if command == "" {
+		return nil, daemonError{Code: "invalid_argument", Message: "command is required"}
+	}
+
+	if h.daemon != nil && h.daemon.hasLocalRuntime() {
+		clip, ok, err := h.daemon.registry.GetClip(clipName)
+		if err != nil {
+			return nil, daemonError{Code: "internal", Message: fmt.Sprintf("load clip: %v", err)}
+		}
+		if ok {
+			return h.invokeLocalClipCollect(ctx, clip, command, input)
+		}
+	}
+	if h.daemon.provider == nil || !h.daemon.provider.HasClip(clipName) {
+		return nil, daemonError{Code: "not_found", Message: fmt.Sprintf("clip %q not found", clipName)}
+	}
+	return h.invokeProviderClipCollect(ctx, clipName, command, input)
+}
+
+func (h *HubService) invokeLocalClipCollect(ctx context.Context, clip ClipConfig, command string, input []byte) (json.RawMessage, error) {
+	if h.daemon == nil || h.daemon.process == nil {
+		return nil, daemonError{Code: "failed_precondition", Message: "local runtime is not configured"}
+	}
+	output, err := h.daemon.process.Invoke(ctx, clip.Name, command, input)
+	if err != nil {
+		return nil, err
+	}
+	if len(output) == 0 {
+		output = []byte(`{}`)
+	}
+	return output, nil
+}
+
+func (h *HubService) invokeProviderClipCollect(ctx context.Context, clipName, command string, input []byte) (json.RawMessage, error) {
+	handle, err := h.daemon.provider.OpenInvoke(clipName, command, input, "")
+	if err != nil {
+		return nil, err
+	}
+	defer handle.Close()
+
+	var chunks []json.RawMessage
+	for {
+		chunk, err := handle.Receive(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if chunk.err != nil {
+			return nil, daemonErrorFromResponseError(chunk.err)
+		}
+		if len(chunk.output) > 0 {
+			chunks = append(chunks, cloneBytes(chunk.output))
+		}
+		if chunk.done {
+			return aggregateInvokeOutputs(chunks), nil
+		}
+	}
+}
+
+// invokeWithCallback routes an invoke through the Hub (local Runtime or Provider)
+// and calls onChunk for each streaming output chunk.
+// Used by handleClipWebInvokeSSE for SSE streaming.
+func (h *HubService) invokeWithCallback(ctx context.Context, clipName, command string, input []byte, onChunk func(json.RawMessage)) error {
+	clipName = strings.TrimSpace(clipName)
+	command = strings.TrimSpace(command)
+	if clipName == "" {
+		return daemonError{Code: "invalid_argument", Message: "clip_name is required"}
+	}
+	if command == "" {
+		return daemonError{Code: "invalid_argument", Message: "command is required"}
+	}
+
+	if h.daemon != nil && h.daemon.hasLocalRuntime() {
+		clip, ok, err := h.daemon.registry.GetClip(clipName)
+		if err != nil {
+			return daemonError{Code: "internal", Message: fmt.Sprintf("load clip: %v", err)}
+		}
+		if ok {
+			return h.invokeLocalClipCallback(ctx, clip, command, input, onChunk)
+		}
+	}
+	if h.daemon.provider == nil || !h.daemon.provider.HasClip(clipName) {
+		return daemonError{Code: "not_found", Message: fmt.Sprintf("clip %q not found", clipName)}
+	}
+	return h.invokeProviderClipCallback(ctx, clipName, command, input, onChunk)
+}
+
+func (h *HubService) invokeLocalClipCallback(ctx context.Context, clip ClipConfig, command string, input []byte, onChunk func(json.RawMessage)) error {
+	if h.daemon == nil || h.daemon.process == nil {
+		return daemonError{Code: "failed_precondition", Message: "local runtime is not configured"}
+	}
+	_, err := h.daemon.process.InvokeStream(ctx, clip.Name, command, input, onChunk)
+	return err
+}
+
+func (h *HubService) invokeProviderClipCallback(ctx context.Context, clipName, command string, input []byte, onChunk func(json.RawMessage)) error {
+	handle, err := h.daemon.provider.OpenInvoke(clipName, command, input, "")
+	if err != nil {
+		return err
+	}
+	defer handle.Close()
+
+	for {
+		chunk, err := handle.Receive(ctx)
+		if err != nil {
+			return err
+		}
+		if chunk.err != nil {
+			return daemonErrorFromResponseError(chunk.err)
+		}
+		if len(chunk.output) > 0 && onChunk != nil {
+			onChunk(cloneBytes(chunk.output))
+		}
+		if chunk.done {
+			return nil
+		}
+	}
+}
+
 func (h *HubService) invokeLocalClip(ctx context.Context, clip ClipConfig, command string, input []byte, clipToken string, stream *connect.ServerStream[pinixv2.InvokeResponse]) error {
 	if h.daemon == nil || h.daemon.process == nil {
 		return connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("local runtime is not configured"))

--- a/internal/daemon/http.go
+++ b/internal/daemon/http.go
@@ -174,14 +174,6 @@ func (d *Daemon) redirectClipWebRoot(w http.ResponseWriter, r *http.Request, cli
 }
 
 func (d *Daemon) handleClipWebInvoke(w http.ResponseWriter, r *http.Request, clipName, command string) {
-	if _, found, err := d.registry.GetClip(clipName); err != nil {
-		writeJSONError(w, daemonError{Code: "internal", Message: fmt.Sprintf("load clip %q: %v", clipName, err)})
-		return
-	} else if !found {
-		http.NotFound(w, r)
-		return
-	}
-
 	input, err := io.ReadAll(r.Body)
 	if err != nil {
 		writeJSONError(w, daemonError{Code: "internal", Message: fmt.Sprintf("read invoke body: %v", err)})
@@ -196,11 +188,6 @@ func (d *Daemon) handleClipWebInvoke(w http.ResponseWriter, r *http.Request, cli
 		return
 	}
 
-	if d.process == nil {
-		writeJSONError(w, daemonError{Code: "internal", Message: "process manager is not configured"})
-		return
-	}
-
 	// Check if client wants SSE streaming
 	accept := r.Header.Get("Accept")
 	if strings.Contains(accept, "text/event-stream") {
@@ -208,7 +195,8 @@ func (d *Daemon) handleClipWebInvoke(w http.ResponseWriter, r *http.Request, cli
 		return
 	}
 
-	output, err := d.process.Invoke(r.Context(), clipName, command, json.RawMessage(input))
+	hub := NewHubService(d)
+	output, err := hub.invokeCollect(r.Context(), clipName, command, input)
 	if err != nil {
 		writeJSONError(w, err)
 		return
@@ -229,7 +217,8 @@ func (d *Daemon) handleClipWebInvokeSSE(w http.ResponseWriter, r *http.Request, 
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 
-	_, err := d.process.InvokeStream(r.Context(), clipName, command, input, func(chunk json.RawMessage) {
+	hub := NewHubService(d)
+	err := hub.invokeWithCallback(r.Context(), clipName, command, input, func(chunk json.RawMessage) {
 		// If chunk is a JSON string (e.g. "\"...\n\""), unwrap it into raw lines
 		// and emit each JSONL line as a separate SSE event
 		raw := bytes.TrimSpace(chunk)


### PR DESCRIPTION
## Summary

- `handleClipWebInvoke` and `handleClipWebInvokeSSE` now route through Hub (`invokeCollect` / `invokeWithCallback`) instead of calling `d.process` directly
- Same architectural fix as #49 (GetClipWeb): Portal → Hub → Provider, no shortcuts

Fixes the `"process manager is not configured"` error when clip web UI tries to invoke commands.

## Changes

| File | What |
|---|---|
| `http.go` | Remove `d.process` calls, use `NewHubService(d).invokeCollect()` / `invokeWithCallback()` |
| `connect.go` | Add `invokeCollect` + `invokeWithCallback` helpers that route through Hub's local/Provider logic |

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/daemon/...`
- [x] Manual: `curl POST /clips/todo-web/api/list` → returns JSON todo list
- [x] Manual: `/clips/todo-web/` → 200, `/clips/agent/` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)