### PR TITLE
feat: PID file for pinixd auto-discovery (#43)

### DIFF
--- a/cmd/pinix/main.go
+++ b/cmd/pinix/main.go
@@ -102,7 +102,7 @@ func executeInvoke(globals, rest []string) error {
 // parseGlobalFlags extracts --server, --auth-token, and --clip-token values
 // from the globals slice produced by splitGlobalArgs.
 func parseGlobalFlags(globals []string) (serverURL, hubToken, clipToken string) {
-	serverURL = client.DefaultServerURL
+	serverURL = client.DefaultServerURL()
 	hubToken = os.Getenv("PINIX_TOKEN")
 	for i := 0; i < len(globals); i++ {
 		switch globals[i] {
@@ -136,7 +136,7 @@ func newRootCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	rootCmd.PersistentFlags().StringVar(&serverURL, "server", client.DefaultServerURL, "pinixd HubService base URL")
+	rootCmd.PersistentFlags().StringVar(&serverURL, "server", client.DefaultServerURL(), "pinixd HubService base URL")
 	rootCmd.PersistentFlags().StringVar(&hubToken, "auth-token", os.Getenv("PINIX_TOKEN"), "hub auth token for protected add/remove operations")
 
 	rootCmd.AddCommand(newAddCommand(&serverURL, &hubToken))
@@ -276,7 +276,7 @@ func newInvokeCommand() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&serverURL, "server", client.DefaultServerURL, "pinixd HubService base URL")
+	cmd.Flags().StringVar(&serverURL, "server", client.DefaultServerURL(), "pinixd HubService base URL")
 	cmd.Flags().StringVar(&hubToken, "auth-token", os.Getenv("PINIX_TOKEN"), "hub auth token")
 	cmd.Flags().StringVar(&clipToken, "clip-token", "", "clip token for protected invoke operations")
 	return cmd

--- a/cmd/pinixd/main.go
+++ b/cmd/pinixd/main.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/epiral/pinix/internal/daemon"
+	"github.com/epiral/pinix/internal/pidfile"
 )
 
 func main() {
@@ -54,6 +55,16 @@ func main() {
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+
+	// PID file: prevent duplicate pinixd, enable CLI auto-discovery
+	if err := pidfile.CheckExistingPIDFile(port); err != nil {
+		exitErr(err)
+	}
+	pidCleanup, err := pidfile.WritePIDFile(port)
+	if err != nil {
+		exitErr(fmt.Errorf("write pid file: %w", err))
+	}
+	defer pidCleanup()
 
 	// Mode 1: Hub only (no local runtime)
 	if hubOnly {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,6 +1,6 @@
 // Role:    Connect-RPC HubService client used by pinix CLI and mock providers
-// Depends: context, crypto/tls, encoding/json, errors, fmt, io, net, net/http, strings, connectrpc, pinix v2, pinixv2connect, http2
-// Exports: Client, HubError, DefaultServerURL, New
+// Depends: context, crypto/tls, encoding/json, errors, fmt, io, net, net/http, strings, connectrpc, pinix v2, pinixv2connect, http2, pidfile
+// Exports: Client, HubError, FallbackServerURL, DefaultServerURL, New
 
 package client
 
@@ -18,10 +18,20 @@ import (
 	connect "connectrpc.com/connect"
 	pinixv2 "github.com/epiral/pinix/gen/go/pinix/v2"
 	"github.com/epiral/pinix/gen/go/pinix/v2/pinixv2connect"
+	"github.com/epiral/pinix/internal/pidfile"
 	"golang.org/x/net/http2"
 )
 
-const DefaultServerURL = "http://127.0.0.1:9000"
+const FallbackServerURL = "http://127.0.0.1:9000"
+
+// DefaultServerURL returns the Hub URL, auto-discovering from PID file if available.
+func DefaultServerURL() string {
+	pf, err := pidfile.ReadPIDFile()
+	if err == nil && pf != nil {
+		return pf.HubURL
+	}
+	return FallbackServerURL
+}
 
 type Client struct {
 	baseURL string
@@ -46,7 +56,7 @@ func (e *HubError) Error() string {
 func New(serverURL string) (*Client, error) {
 	serverURL = strings.TrimSpace(serverURL)
 	if serverURL == "" {
-		serverURL = DefaultServerURL
+		serverURL = DefaultServerURL()
 	}
 
 	transport := &http2.Transport{

--- a/internal/pidfile/pidfile.go
+++ b/internal/pidfile/pidfile.go
@@ -1,0 +1,112 @@
+// Role:    PID file management for pinixd — write, read, validate, and clean stale PID files
+// Depends: encoding/json, fmt, os, path/filepath, strconv, syscall, time
+// Exports: PIDFile, WritePIDFile, ReadPIDFile, CheckExistingPIDFile
+
+package pidfile
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+// PIDFile represents the contents of the pinixd PID file.
+type PIDFile struct {
+	PID       int    `json:"pid"`
+	Port      int    `json:"port"`
+	StartedAt string `json:"startedAt"`
+	HubURL    string `json:"hubURL"`
+}
+
+// pidFilePath returns the path to ~/.pinix/pinixd.pid.
+func pidFilePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("get home directory: %w", err)
+	}
+	return filepath.Join(home, ".pinix", "pinixd.pid"), nil
+}
+
+// WritePIDFile writes the PID file with current process info.
+// Returns a cleanup function that removes the file.
+func WritePIDFile(port int) (cleanup func(), err error) {
+	path, err := pidFilePath()
+	if err != nil {
+		return nil, err
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("create pid file directory: %w", err)
+	}
+
+	pf := PIDFile{
+		PID:       os.Getpid(),
+		Port:      port,
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+		HubURL:    fmt.Sprintf("http://127.0.0.1:%d", port),
+	}
+
+	data, err := json.MarshalIndent(pf, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal pid file: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return nil, fmt.Errorf("write pid file: %w", err)
+	}
+
+	cleanup = func() {
+		_ = os.Remove(path)
+	}
+	return cleanup, nil
+}
+
+// ReadPIDFile reads and validates the PID file.
+// Returns nil, nil if the file doesn't exist or the process is dead (stale file is auto-cleaned).
+func ReadPIDFile() (*PIDFile, error) {
+	path, err := pidFilePath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read pid file: %w", err)
+	}
+
+	var pf PIDFile
+	if err := json.Unmarshal(data, &pf); err != nil {
+		// Corrupt file — remove it
+		_ = os.Remove(path)
+		return nil, nil
+	}
+
+	// Check if process is still alive
+	if err := syscall.Kill(pf.PID, 0); err != nil {
+		// Process is dead — remove stale file
+		_ = os.Remove(path)
+		return nil, nil
+	}
+
+	return &pf, nil
+}
+
+// CheckExistingPIDFile checks if another pinixd is already running.
+// Returns an error if a live process is found.
+func CheckExistingPIDFile(port int) error {
+	pf, err := ReadPIDFile()
+	if err != nil {
+		return err
+	}
+	if pf == nil {
+		return nil
+	}
+	return fmt.Errorf("pinixd is already running (pid %d, port %d)", pf.PID, pf.Port)
+}


### PR DESCRIPTION
## Summary

pinixd now writes a PID file at `~/.pinix/pinixd.pid` on startup, enabling `pinix` CLI to auto-discover the running Hub without `--server` flag.

### PID file (`~/.pinix/pinixd.pid`)
```json
{
  "pid": 12345,
  "port": 9007,
  "startedAt": "2026-03-24T11:00:00Z",
  "hubURL": "http://127.0.0.1:9007"
}
```

### Behavior
- **Startup**: checks for existing live pinixd → writes PID file
- **Shutdown**: defer removes PID file (SIGTERM/SIGINT handled by signal.NotifyContext)
- **Stale detection**: if PID file exists but process is dead, auto-cleans
- **CLI auto-discovery**: `pinix list` reads PID file → no `--server` needed

### New package: `internal/pidfile/`
Standalone package with `WritePIDFile`, `ReadPIDFile`, `CheckExistingPIDFile`. No dependencies on daemon or client packages.

### Before/After
```bash
# Before
pinix --server http://127.0.0.1:9007 list

# After
pinix list
```

Implements Phase 1 of #43

## Test plan
- [x] `go build ./...` / `go vet ./...` pass
- [x] PID file created on pinixd start
- [x] `pinix list` auto-discovers without `--server`
- [x] PID file removed on graceful shutdown
- [x] Stale PID files auto-cleaned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>