### PR TITLE
feat: config set hub/hub-token + pinixd --pid

### DIFF
--- a/cmd/pinix/config.go
+++ b/cmd/pinix/config.go
@@ -19,6 +19,8 @@ const defaultRegistryURL = "https://api.pinix.ai"
 
 type clientConfig struct {
 	Registry string `json:"registry,omitempty"`
+	Hub      string `json:"hub,omitempty"`
+	HubToken string `json:"hub_token,omitempty"`
 }
 
 func newConfigCommand() *cobra.Command {
@@ -48,8 +50,12 @@ func newConfigSetCommand() *cobra.Command {
 			switch key {
 			case "registry":
 				cfg.Registry = value
+			case "hub":
+				cfg.Hub = value
+			case "hub-token":
+				cfg.HubToken = value
 			default:
-				return fmt.Errorf("unknown config key %q; supported keys: registry", key)
+				return fmt.Errorf("unknown config key %q; supported keys: registry, hub, hub-token", key)
 			}
 
 			if err := saveClientConfig(cfg); err != nil {
@@ -81,8 +87,12 @@ func newConfigGetCommand() *cobra.Command {
 					value = defaultRegistryURL
 				}
 				fmt.Fprintln(cmd.OutOrStdout(), value)
+			case "hub":
+				fmt.Fprintln(cmd.OutOrStdout(), cfg.Hub)
+			case "hub-token":
+				fmt.Fprintln(cmd.OutOrStdout(), cfg.HubToken)
 			default:
-				return fmt.Errorf("unknown config key %q; supported keys: registry", key)
+				return fmt.Errorf("unknown config key %q; supported keys: registry, hub, hub-token", key)
 			}
 			return nil
 		},

--- a/cmd/pinixd/main.go
+++ b/cmd/pinixd/main.go
@@ -6,11 +6,13 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"net"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -28,6 +30,7 @@ func main() {
 		hubURL     string
 		hubToken   string
 		port       int
+		pidPath    string
 		hubOnly    bool
 	)
 
@@ -38,13 +41,26 @@ func main() {
 	flag.StringVar(&hubToken, "hub-token", "", "JWT token for authenticating with the external hub (env: PINIX_HUB_TOKEN)")
 	flag.BoolVar(&hubOnly, "hub-only", false, "run Hub + Portal only, without a local runtime")
 	flag.IntVar(&port, "port", 9000, "http port for the embedded portal UI; used in provider identity for --hub mode")
+	flag.StringVar(&pidPath, "pid", "", "custom path to PID file (default: ~/.pinix/pinixd.pid)")
 	flag.Parse()
 
+	// Resolve hub-token: flag > env > config file
 	if hubToken == "" {
 		hubToken = strings.TrimSpace(os.Getenv("PINIX_HUB_TOKEN"))
 	}
+	if hubToken == "" {
+		hubToken = readClientConfigValue("hub_token")
+	}
 
+	// Resolve hub: flag > env > config file
 	hubURL = strings.TrimSpace(hubURL)
+	if hubURL == "" {
+		if v := strings.TrimSpace(os.Getenv("PINIX_HUB")); v != "" {
+			hubURL = v
+		} else {
+			hubURL = readClientConfigValue("hub")
+		}
+	}
 	if hubOnly && hubURL != "" {
 		exitErr(fmt.Errorf("--hub and --hub-only cannot be used together"))
 	}
@@ -63,10 +79,10 @@ func main() {
 	defer stop()
 
 	// PID file: prevent duplicate pinixd, enable CLI auto-discovery
-	if err := pidfile.CheckExistingPIDFile(port); err != nil {
+	if err := pidfile.CheckExistingPIDFile(port, pidPath); err != nil {
 		exitErr(err)
 	}
-	pidCleanup, err := pidfile.WritePIDFile(port)
+	pidCleanup, err := pidfile.WritePIDFile(port, pidPath)
 	if err != nil {
 		exitErr(fmt.Errorf("write pid file: %w", err))
 	}
@@ -181,6 +197,24 @@ func waitForHub(ctx context.Context, hubURL string, timeout time.Duration) error
 		time.Sleep(50 * time.Millisecond)
 	}
 	return fmt.Errorf("timeout waiting for %s", hubURL)
+}
+
+// readClientConfigValue reads a single value from ~/.pinix/client.json.
+// Returns empty string on any error.
+func readClientConfigValue(key string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".pinix", "client.json"))
+	if err != nil {
+		return ""
+	}
+	var cfg map[string]string
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(cfg[key])
 }
 
 func exitErr(err error) {

--- a/internal/daemon/runtime_hub.go
+++ b/internal/daemon/runtime_hub.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	stdruntime "runtime"
 	"strings"
@@ -58,8 +59,10 @@ func (d *Daemon) ConnectHub(ctx context.Context, hubURL string, port int, hubTok
 		return fmt.Errorf("hub URL is required")
 	}
 
+	slog.Info("hub: connecting", "url", hubURL, "token_len", len(hubToken))
 	cli, err := clientpkg.New(hubURL)
 	if err != nil {
+		slog.Error("hub: failed to create client", "error", err)
 		return err
 	}
 	d.process.SetHubClient(cli, hubToken)
@@ -174,21 +177,27 @@ func (c *runtimeHubConnector) runProviderSession(parent context.Context) error {
 	sessionCtx, cancel := context.WithCancel(parent)
 	defer cancel()
 
+	slog.Info("hub: opening ProviderStream", "url", c.client.BaseURL(), "token_len", len(c.hubToken))
 	stream := c.client.ProviderStream(sessionCtx, c.hubToken)
 	defer stream.CloseRequest()
 	defer stream.CloseResponse()
 
 	register, err := c.registerMessage(sessionCtx)
 	if err != nil {
+		slog.Error("hub: failed to build register message", "error", err)
 		return err
 	}
+	slog.Info("hub: sending register message", "provider", c.providerName, "clips", len(register.GetPayload().(*pinixv2.ProviderMessage_Register).Register.GetClips()))
 	if err := c.sendProvider(stream, register); err != nil {
+		slog.Error("hub: failed to send register message", "error", err)
 		return err
 	}
+	slog.Info("hub: register message sent, waiting for response")
 
 	for {
 		message, err := stream.Receive()
 		if err != nil {
+			slog.Error("hub: receive error", "error", err)
 			if parent.Err() != nil || sessionCtx.Err() != nil {
 				return nil
 			}
@@ -199,6 +208,7 @@ func (c *runtimeHubConnector) runProviderSession(parent context.Context) error {
 		}
 
 		if response := message.GetRegisterResponse(); response != nil {
+			slog.Info("hub: register response", "accepted", response.GetAccepted(), "message", response.GetMessage())
 			if !response.GetAccepted() {
 				msg := strings.TrimSpace(response.GetMessage())
 				if msg == "" {

--- a/internal/pidfile/pidfile.go
+++ b/internal/pidfile/pidfile.go
@@ -21,8 +21,8 @@ type PIDFile struct {
 	HubURL    string `json:"hubURL"`
 }
 
-// pidFilePath returns the path to ~/.pinix/pinixd.pid.
-func pidFilePath() (string, error) {
+// defaultPIDFilePath returns the default path ~/.pinix/pinixd.pid.
+func defaultPIDFilePath() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("get home directory: %w", err)
@@ -30,10 +30,23 @@ func pidFilePath() (string, error) {
 	return filepath.Join(home, ".pinix", "pinixd.pid"), nil
 }
 
+// resolvePIDPath returns customPath if non-empty, otherwise the default path.
+func resolvePIDPath(customPath string) (string, error) {
+	if customPath != "" {
+		return customPath, nil
+	}
+	return defaultPIDFilePath()
+}
+
 // WritePIDFile writes the PID file with current process info.
+// If customPath is provided, uses that path instead of the default.
 // Returns a cleanup function that removes the file.
-func WritePIDFile(port int) (cleanup func(), err error) {
-	path, err := pidFilePath()
+func WritePIDFile(port int, customPath ...string) (cleanup func(), err error) {
+	cp := ""
+	if len(customPath) > 0 {
+		cp = customPath[0]
+	}
+	path, err := resolvePIDPath(cp)
 	if err != nil {
 		return nil, err
 	}
@@ -66,9 +79,14 @@ func WritePIDFile(port int) (cleanup func(), err error) {
 }
 
 // ReadPIDFile reads and validates the PID file.
+// If customPath is provided, uses that path instead of the default.
 // Returns nil, nil if the file doesn't exist or the process is dead (stale file is auto-cleaned).
-func ReadPIDFile() (*PIDFile, error) {
-	path, err := pidFilePath()
+func ReadPIDFile(customPath ...string) (*PIDFile, error) {
+	cp := ""
+	if len(customPath) > 0 {
+		cp = customPath[0]
+	}
+	path, err := resolvePIDPath(cp)
 	if err != nil {
 		return nil, err
 	}
@@ -99,9 +117,10 @@ func ReadPIDFile() (*PIDFile, error) {
 }
 
 // CheckExistingPIDFile checks if another pinixd is already running.
+// If customPath is provided, checks that specific PID file.
 // Returns an error if a live process is found.
-func CheckExistingPIDFile(port int) error {
-	pf, err := ReadPIDFile()
+func CheckExistingPIDFile(port int, customPath ...string) error {
+	pf, err := ReadPIDFile(customPath...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- `pinix config set hub <url>` / `pinix config set hub-token <token>` — 保存到 `~/.pinix/client.json`
- `pinixd` 自动从 config file 读取 hub/hub-token（优先级：flag > env > config > 无）
- `pinixd --pid /tmp/pinixd-dev.pid` — 自定义 PID 文件路径，支持多实例
- hub 连接流程增加 debug logging

## Test plan

- [x] `pinix config set hub` / `pinix config get hub` 正常读写
- [x] `pinix config set hub-token` / `pinix config get hub-token` 正常读写
- [x] `~/.pinix/client.json` 格式正确
- [x] `pinixd --pid /tmp/test.pid` 写入自定义路径
- [x] PID 文件在进程退出后自动清理
- [x] 不传 `--pid` 时行为不变（backward compatible）
- [x] `go build ./cmd/pinix && go build ./cmd/pinixd` 编译通过

Closes #68, Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)