### PR TITLE
fix: h2c transport + Search API unification

### DIFF
--- a/cmd/clip-edge-linux/main.go
+++ b/cmd/clip-edge-linux/main.go
@@ -1,18 +1,16 @@
 // Role:    Edge Clip Provider binary that connects to a remote Hub registering Linux system capabilities
-// Depends: context, crypto/tls, errors, flag, fmt, io, log, net, net/http, os, os/signal, strings, sync, syscall, time, connectrpc, pinix v2, pinixv2connect, edgelinux, http2
+// Depends: context, errors, flag, fmt, io, log, net/http, os, os/signal, strings, sync, syscall, time, connectrpc, pinix v2, pinixv2connect, edgelinux
 // Exports: main
 
 package main
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"log"
-	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -25,7 +23,6 @@ import (
 	pinixv2 "github.com/epiral/pinix/gen/go/pinix/v2"
 	"github.com/epiral/pinix/gen/go/pinix/v2/pinixv2connect"
 	"github.com/epiral/pinix/internal/edgelinux"
-	"golang.org/x/net/http2"
 )
 
 const (
@@ -70,14 +67,12 @@ func main() {
 }
 
 func runProvider(parent context.Context, hubURL, providerName string) error {
-	transport := &http2.Transport{
-		AllowHTTP: true,
-		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
-			var dialer net.Dialer
-			return dialer.DialContext(ctx, network, addr)
-		},
+	var protocols http.Protocols
+	protocols.SetHTTP2(true)
+	protocols.SetUnencryptedHTTP2(true)
+	httpClient := &http.Client{
+		Transport: &http.Transport{Protocols: &protocols},
 	}
-	httpClient := &http.Client{Transport: transport}
 
 	client := pinixv2connect.NewHubServiceClient(httpClient, hubURL, connect.WithGRPC())
 

--- a/cmd/pinix/registry.go
+++ b/cmd/pinix/registry.go
@@ -62,7 +62,7 @@ func newSearchCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			resp, err := reg.Search(cmd.Context(), args[0], domain, packageType)
+			resp, err := reg.Search(cmd.Context(), args[0], domain, packageType, 0, 0)
 			if err != nil {
 				return err
 			}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,17 +1,15 @@
 // Role:    Connect-RPC HubService client used by pinix CLI and mock providers
-// Depends: context, crypto/tls, encoding/json, errors, fmt, io, net, net/http, strings, connectrpc, pinix v2, pinixv2connect, http2, pidfile
+// Depends: context, encoding/json, errors, fmt, io, net/http, strings, connectrpc, pinix v2, pinixv2connect, pidfile
 // Exports: Client, HubError, FallbackServerURL, DefaultServerURL, New
 
 package client
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"strings"
 
@@ -19,7 +17,6 @@ import (
 	pinixv2 "github.com/epiral/pinix/gen/go/pinix/v2"
 	"github.com/epiral/pinix/gen/go/pinix/v2/pinixv2connect"
 	"github.com/epiral/pinix/internal/pidfile"
-	"golang.org/x/net/http2"
 )
 
 const FallbackServerURL = "http://127.0.0.1:9000"
@@ -59,17 +56,12 @@ func New(serverURL string) (*Client, error) {
 		serverURL = DefaultServerURL()
 	}
 
-	transport := &http2.Transport{
-		AllowHTTP: true,
-		DialTLSContext: func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
-			if cfg != nil {
-				return tls.DialWithDialer(&net.Dialer{}, network, addr, cfg)
-			}
-			var d net.Dialer
-			return d.DialContext(ctx, network, addr)
-		},
+	var protocols http.Protocols
+	protocols.SetHTTP2(true)
+	protocols.SetUnencryptedHTTP2(true)
+	httpClient := &http.Client{
+		Transport: &http.Transport{Protocols: &protocols},
 	}
-	httpClient := &http.Client{Transport: transport}
 
 	return &Client{
 		baseURL: strings.TrimRight(serverURL, "/"),

--- a/internal/client/registry.go
+++ b/internal/client/registry.go
@@ -67,8 +67,9 @@ func (d *RegistryPackageDocument) mergeDistTags() {
 }
 
 type RegistrySearchResponse struct {
-	Results []RegistrySearchResult `json:"results"`
-	Total   int                    `json:"total"`
+	Results  []RegistrySearchResult `json:"results"`
+	Packages []RegistrySearchResult `json:"packages"`
+	Total    int                    `json:"total"`
 }
 
 type RegistrySearchResult struct {
@@ -208,7 +209,7 @@ func (d *RegistryPackageDocument) ResolveVersion(requested string) (string, *Reg
 	return requested, &copy, nil
 }
 
-func (c *RegistryClient) Search(ctx context.Context, query, domain, packageType string) (*RegistrySearchResponse, error) {
+func (c *RegistryClient) Search(ctx context.Context, query, domain, packageType string, limit, offset int) (*RegistrySearchResponse, error) {
 	values := url.Values{}
 	values.Set("q", strings.TrimSpace(query))
 	if strings.TrimSpace(domain) != "" {
@@ -217,10 +218,21 @@ func (c *RegistryClient) Search(ctx context.Context, query, domain, packageType 
 	if strings.TrimSpace(packageType) != "" {
 		values.Set("type", strings.TrimSpace(packageType))
 	}
+	if limit > 0 {
+		values.Set("limit", fmt.Sprintf("%d", limit))
+	}
+	if offset > 0 {
+		values.Set("offset", fmt.Sprintf("%d", offset))
+	}
 	var resp RegistrySearchResponse
 	if err := c.getJSON(ctx, "/search?"+values.Encode(), &resp); err != nil {
 		return nil, err
 	}
+	// Merge packages into results for compatibility with commercial registry.
+	if len(resp.Packages) > 0 && len(resp.Results) == 0 {
+		resp.Results = resp.Packages
+	}
+	resp.Packages = nil
 	return &resp, nil
 }
 

--- a/internal/daemon/http.go
+++ b/internal/daemon/http.go
@@ -1,5 +1,5 @@
 // Role:    Embedded HTTP server for the Pinix portal, Connect-RPC, clip web files, and JSON errors
-// Depends: bytes, context, encoding/json, errors, fmt, io, net, net/http, strings, time, connectrpc, pinix v2, pinixv2connect, github.com/epiral/pinix/web, http2, h2c
+// Depends: bytes, context, encoding/json, errors, fmt, io, net, net/http, strings, time, connectrpc, pinix v2, pinixv2connect, github.com/epiral/pinix/web
 // Exports: Daemon.ServeHTTP
 
 package daemon
@@ -21,8 +21,6 @@ import (
 	pinixv2 "github.com/epiral/pinix/gen/go/pinix/v2"
 	"github.com/epiral/pinix/gen/go/pinix/v2/pinixv2connect"
 	portalweb "github.com/epiral/pinix/web"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 )
 
 func (d *Daemon) ServeHTTP(ctx context.Context, addr string) error {
@@ -35,9 +33,14 @@ func (d *Daemon) ServeHTTP(ctx context.Context, addr string) error {
 		return fmt.Errorf("listen on %s: %w", addr, err)
 	}
 
+	var protocols http.Protocols
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+
 	server := &http.Server{
 		Addr:              addr,
-		Handler:           h2c.NewHandler(d.httpMux(), &http2.Server{}),
+		Handler:           d.httpMux(),
+		Protocols:         &protocols,
 		ReadHeaderTimeout: 10 * time.Second,
 		IdleTimeout:       120 * time.Second,
 		BaseContext: func(net.Listener) context.Context {


### PR DESCRIPTION
## Summary
- Replace `golang.org/x/net/http2` h2c hack with Go 1.25 native `http.Protocols` API
- Fix "server gave HTTP response to HTTPS client" on Go 1.25.1
- Unify Search API: add `limit`/`offset` params to `RegistryClient.Search()`

## Changes
- **Server** (`http.go`): `h2c.NewHandler` → `http.Server{Protocols: SetUnencryptedHTTP2}`
- **Client** (`client.go`): `http2.Transport{AllowHTTP}` → `http.Transport{Protocols: SetUnencryptedHTTP2}`
- **Edge Linux** (`main.go`): Same transport fix
- **Registry client**: Add `limit`, `offset` params; `Packages` field for commercial compat

## Test plan
- [x] Local e2e: pinixd starts, CLI connects via h2c, ProviderStream bidi works
- [x] `buf curl` unary + streaming invoke both pass
- [x] Second pinixd `--hub` connects successfully (ProviderStream)
- [ ] Cloud Hub HTTPS connection (needs deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)