### PR TITLE
feat: IPC list_clips — runtime capability discovery

### DIFF
--- a/internal/daemon/process.go
+++ b/internal/daemon/process.go
@@ -498,6 +498,12 @@ func (m *ProcessManager) handleMessage(proc *clipProcess, message *ipc.Message) 
 		}
 		m.handleClipInvoke(proc, *message)
 		return nil
+	case ipc.MessageTypeListClips:
+		if strings.TrimSpace(message.ID) == "" {
+			return fmt.Errorf("ipc list_clips id is required")
+		}
+		go m.handleListClips(proc, message.ID)
+		return nil
 	case ipc.MessageTypeResult, ipc.MessageTypeError, ipc.MessageTypeChunk, ipc.MessageTypeDone:
 		if strings.TrimSpace(message.ID) == "" {
 			return fmt.Errorf("ipc %s id is required", message.Type)
@@ -527,6 +533,46 @@ func (m *ProcessManager) handleRegister(proc *clipProcess, message *ipc.Message)
 	}
 	proc.signalReady()
 	return nil
+}
+
+func (m *ProcessManager) handleListClips(proc *clipProcess, requestID string) {
+	clips, err := m.registry.ListClips()
+	if err != nil {
+		_ = proc.send(&ipc.Message{
+			ID:    requestID,
+			Type:  ipc.MessageTypeError,
+			Error: fmt.Sprintf("list clips: %v", err),
+		})
+		return
+	}
+
+	infos := make([]ipc.ListClipInfo, 0, len(clips))
+	for _, clip := range clips {
+		manifest := enrichManifestForClip(clip, clip.Manifest)
+		commands := make([]ipc.ListCommandInfo, 0, len(manifest.CommandDetails))
+		for _, cmd := range manifest.CommandDetails {
+			commands = append(commands, ipc.ListCommandInfo{
+				Name:        cmd.Name,
+				Description: cmd.Description,
+			})
+		}
+		infos = append(infos, ipc.ListClipInfo{
+			Name:     clip.Name,
+			Package:  manifest.Package,
+			Version:  manifest.Version,
+			Commands: commands,
+		})
+	}
+
+	sort.Slice(infos, func(i, j int) bool {
+		return infos[i].Name < infos[j].Name
+	})
+
+	_ = proc.send(&ipc.Message{
+		ID:    requestID,
+		Type:  ipc.MessageTypeListClipsResult,
+		Clips: infos,
+	})
 }
 
 func (m *ProcessManager) handleClipInvoke(proc *clipProcess, message ipc.Message) {

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -14,13 +14,15 @@ import (
 var ErrClosed = errors.New("ipc client closed")
 
 const (
-	MessageTypeRegister   = "register"
-	MessageTypeRegistered = "registered"
-	MessageTypeInvoke     = "invoke"
-	MessageTypeResult     = "result"
-	MessageTypeError      = "error"
-	MessageTypeChunk      = "chunk"
-	MessageTypeDone       = "done"
+	MessageTypeRegister       = "register"
+	MessageTypeRegistered     = "registered"
+	MessageTypeInvoke         = "invoke"
+	MessageTypeResult         = "result"
+	MessageTypeError          = "error"
+	MessageTypeChunk          = "chunk"
+	MessageTypeDone           = "done"
+	MessageTypeListClips      = "list_clips"
+	MessageTypeListClipsResult = "list_clips_result"
 )
 
 type Message struct {
@@ -33,6 +35,19 @@ type Message struct {
 	Output   json.RawMessage `json:"output,omitempty"`
 	Error    string          `json:"error,omitempty"`
 	Manifest *Manifest       `json:"manifest,omitempty"`
+	Clips    []ListClipInfo  `json:"clips,omitempty"`
+}
+
+type ListClipInfo struct {
+	Name     string            `json:"name"`
+	Package  string            `json:"package,omitempty"`
+	Version  string            `json:"version,omitempty"`
+	Commands []ListCommandInfo `json:"commands,omitempty"`
+}
+
+type ListCommandInfo struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
 }
 
 type Manifest struct {


### PR DESCRIPTION
## Summary
- pinixd handles `list_clips` IPC message from clip processes
- Returns all clips visible to the runtime (local + provider)
- Enables clips to discover available capabilities without Hub auth token

Ref: #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)