### PR TITLE
fix: IPC listClips queries Hub instead of local registry

### DIFF
--- a/internal/daemon/process.go
+++ b/internal/daemon/process.go
@@ -536,34 +536,67 @@ func (m *ProcessManager) handleRegister(proc *clipProcess, message *ipc.Message)
 }
 
 func (m *ProcessManager) handleListClips(proc *clipProcess, requestID string) {
-	clips, err := m.registry.ListClips()
-	if err != nil {
-		_ = proc.send(&ipc.Message{
-			ID:    requestID,
-			Type:  ipc.MessageTypeError,
-			Error: fmt.Sprintf("list clips: %v", err),
-		})
-		return
-	}
+	var infos []ipc.ListClipInfo
 
-	infos := make([]ipc.ListClipInfo, 0, len(clips))
-	for _, clip := range clips {
-		manifest := enrichManifestForClip(clip, clip.Manifest)
-		commands := make([]ipc.ListCommandInfo, 0, len(manifest.CommandDetails))
-		for _, cmd := range manifest.CommandDetails {
-			commands = append(commands, ipc.ListCommandInfo{
-				Name:        cmd.Name,
-				Description: cmd.Description,
-				Input:       cmd.Input,
-				Output:      cmd.Output,
+	if m.hub != nil {
+		// Query the Hub to discover ALL clips across all providers.
+		clips, err := m.hub.ListClips(context.Background(), m.hubToken)
+		if err != nil {
+			_ = proc.send(&ipc.Message{
+				ID:    requestID,
+				Type:  ipc.MessageTypeError,
+				Error: fmt.Sprintf("list clips from hub: %v", err),
+			})
+			return
+		}
+		infos = make([]ipc.ListClipInfo, 0, len(clips))
+		for _, clip := range clips {
+			commands := make([]ipc.ListCommandInfo, 0, len(clip.GetCommands()))
+			for _, cmd := range clip.GetCommands() {
+				commands = append(commands, ipc.ListCommandInfo{
+					Name:        cmd.GetName(),
+					Description: cmd.GetDescription(),
+					Input:       cmd.GetInput(),
+					Output:      cmd.GetOutput(),
+				})
+			}
+			infos = append(infos, ipc.ListClipInfo{
+				Name:     clip.GetName(),
+				Package:  clip.GetPackage(),
+				Version:  clip.GetVersion(),
+				Commands: commands,
 			})
 		}
-		infos = append(infos, ipc.ListClipInfo{
-			Name:     clip.Name,
-			Package:  manifest.Package,
-			Version:  manifest.Version,
-			Commands: commands,
-		})
+	} else {
+		// Fallback to local registry when Hub client is not available.
+		clips, err := m.registry.ListClips()
+		if err != nil {
+			_ = proc.send(&ipc.Message{
+				ID:    requestID,
+				Type:  ipc.MessageTypeError,
+				Error: fmt.Sprintf("list clips: %v", err),
+			})
+			return
+		}
+		infos = make([]ipc.ListClipInfo, 0, len(clips))
+		for _, clip := range clips {
+			manifest := enrichManifestForClip(clip, clip.Manifest)
+			commands := make([]ipc.ListCommandInfo, 0, len(manifest.CommandDetails))
+			for _, cmd := range manifest.CommandDetails {
+				commands = append(commands, ipc.ListCommandInfo{
+					Name:        cmd.Name,
+					Description: cmd.Description,
+					Input:       cmd.Input,
+					Output:      cmd.Output,
+				})
+			}
+			infos = append(infos, ipc.ListClipInfo{
+				Name:     clip.Name,
+				Package:  manifest.Package,
+				Version:  manifest.Version,
+				Commands: commands,
+			})
+		}
 	}
 
 	sort.Slice(infos, func(i, j int) bool {


### PR DESCRIPTION
## Summary
- `handleListClips` now queries the Hub's `ListClips` RPC when `m.hub` is available, returning clips from ALL connected providers
- Falls back to local registry when Hub client is nil
- Fixes agent-clip not discovering cross-provider clips (e.g. browser on bb-browserd)

Closes #94

## Test plan
- [x] Mac Mini 部署验证：agent `pkg list` 返回 8 个 clip（含 bb-browserd 的 browser）
- [ ] 单机模式行为不变
- [ ] e2e-local S29 环境下 listClips 返回两个 pinixd 的 clip

🤖 Generated with [Claude Code](https://claude.com/claude-code)