### PR TITLE
fix: publish response parsing + info re-inspect for local clips

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -74,6 +74,17 @@ func (d *Daemon) GetManifest(ctx context.Context, name string) (*ManifestCache, 
 			return nil, daemonError{Code: "internal", Message: fmt.Sprintf("load clip: %v", err)}
 		}
 		if ok {
+			// Local clips: always re-inspect since source files may have changed.
+			if strings.HasPrefix(clip.Source, "local/") {
+				manifest, err := d.process.LoadManifest(ctx, clip.Name)
+				if err == nil && manifest != nil {
+					clip.Manifest = manifest
+					_ = d.registry.PutClip(clip)
+					return enrichManifestForClip(clip, manifest), nil
+				}
+				// Fall through to cached manifest if re-inspect fails.
+			}
+
 			if clip.Manifest != nil {
 				return enrichManifestForClip(clip, clip.Manifest), nil
 			}


### PR DESCRIPTION
## Summary
- `RegistryPublishResponse`: add `"package"` field + `GetName()` method to handle both old (`package`) and new (`name`) server response formats
- `pinix info`: re-inspect local clips on every call since source files may change on disk, instead of returning stale cached manifest

## Test plan
- [ ] `pinix publish` displays correct package name (not empty)
- [ ] `pinix info <local-clip>` reflects changes to local clip.json
- [ ] `pinix info <registry-clip>` still uses cached manifest (no regression)

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)