### PR TITLE
refactor: CLI 命令体系重构 — hub/registry/invoke

### DIFF
--- a/cmd/pinix/hub.go
+++ b/cmd/pinix/hub.go
@@ -1,0 +1,174 @@
+// Role:    Hub subcommand group — manage Clips through a Pinix Hub
+// Depends: fmt, os, strings, internal/client, internal/config, internal/pidfile, cobra
+// Exports: newHubCommand, defaultHubURL, defaultHubToken
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/epiral/pinix/internal/client"
+	configpkg "github.com/epiral/pinix/internal/config"
+	"github.com/epiral/pinix/internal/pidfile"
+	"github.com/spf13/cobra"
+)
+
+// defaultHubURL resolves the Hub URL from: PID file > client.json > fallback.
+func defaultHubURL() string {
+	pf, err := pidfile.ReadPIDFile()
+	if err == nil && pf != nil {
+		return pf.HubURL
+	}
+	cfg, err := configpkg.ReadClientConfig()
+	if err == nil && strings.TrimSpace(cfg.Hub) != "" {
+		return strings.TrimSpace(cfg.Hub)
+	}
+	return client.FallbackServerURL
+}
+
+// defaultHubToken resolves the Hub token from: env > client.json.
+func defaultHubToken() string {
+	if v := strings.TrimSpace(os.Getenv("PINIX_TOKEN")); v != "" {
+		return v
+	}
+	cfg, err := configpkg.ReadClientConfig()
+	if err == nil && strings.TrimSpace(cfg.HubToken) != "" {
+		return strings.TrimSpace(cfg.HubToken)
+	}
+	return ""
+}
+
+func newHubCommand() *cobra.Command {
+	var serverURL string
+	var hubToken string
+
+	cmd := &cobra.Command{
+		Use:   "hub",
+		Short: "Manage Clips through a Pinix Hub",
+	}
+	cmd.PersistentFlags().StringVar(&serverURL, "server", defaultHubURL(), "Hub URL (default: auto-discover)")
+	cmd.PersistentFlags().StringVar(&hubToken, "auth-token", defaultHubToken(), "Hub auth token")
+
+	cmd.AddCommand(newHubLoginCommand(&serverURL))
+	cmd.AddCommand(newHubLogoutCommand())
+	cmd.AddCommand(newHubWhoAmICommand())
+	cmd.AddCommand(newListCommand(&serverURL, &hubToken))
+	cmd.AddCommand(newAddCommand(&serverURL, &hubToken))
+	cmd.AddCommand(newRemoveCommand(&serverURL, &hubToken))
+	cmd.AddCommand(newInfoCommand(&serverURL, &hubToken))
+	cmd.AddCommand(newUpdateCommand(&serverURL, &hubToken))
+	cmd.AddCommand(newBindCommand(&serverURL, &hubToken))
+	cmd.AddCommand(newUnbindCommand(&serverURL, &hubToken))
+	cmd.AddCommand(newBindingsCommand(&serverURL, &hubToken))
+	cmd.AddCommand(newLogsCommand())
+	cmd.AddCommand(newMCPCommand(&serverURL, &hubToken))
+
+	return cmd
+}
+
+func newHubLoginCommand(serverURL *string) *cobra.Command {
+	var registryURL string
+
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "Log in to a Pinix Hub",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reg, err := requireRegistryClient(registryURL)
+			if err != nil {
+				return err
+			}
+			prompter := newInteractivePrompter(cmd.InOrStdin(), cmd.ErrOrStderr())
+			username, err := prompter.readRequired("Username", true)
+			if err != nil {
+				return err
+			}
+			password, err := prompter.readRequired("Password", false)
+			if err != nil {
+				return err
+			}
+			resp, err := reg.Login(cmd.Context(), username, password)
+			if err != nil {
+				return err
+			}
+			token := strings.TrimSpace(resp.Token)
+			if token == "" {
+				return fmt.Errorf("login response did not include a token")
+			}
+			cfg, err := configpkg.ReadClientConfig()
+			if err != nil {
+				return err
+			}
+			cfg.HubToken = token
+			if v := strings.TrimSpace(*serverURL); v != "" && v != client.FallbackServerURL {
+				cfg.Hub = v
+			}
+			if err := configpkg.WriteClientConfig(cfg); err != nil {
+				return err
+			}
+			hubDisplay := cfg.Hub
+			if hubDisplay == "" {
+				hubDisplay = "default"
+			}
+			username = firstNonEmpty(resp.GetUsername(), username)
+			fmt.Fprintf(cmd.OutOrStdout(), "logged in as %s (hub: %s)\n", username, hubDisplay)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&registryURL, "registry", "", "Registry URL for authentication (default: from config or https://api.pinix.ai)")
+	return cmd
+}
+
+func newHubLogoutCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "logout",
+		Short: "Log out from a Pinix Hub",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := configpkg.ReadClientConfig()
+			if err != nil {
+				return err
+			}
+			cfg.HubToken = ""
+			if err := configpkg.WriteClientConfig(cfg); err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "logged out")
+			return nil
+		},
+	}
+}
+
+func newHubWhoAmICommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "whoami",
+		Short: "Show the current Hub user",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := configpkg.ReadClientConfig()
+			if err != nil {
+				return err
+			}
+			token := strings.TrimSpace(cfg.HubToken)
+			if token == "" {
+				return fmt.Errorf("not logged in; run \"pinix hub login\"")
+			}
+			reg, err := requireRegistryClient("")
+			if err != nil {
+				return err
+			}
+			resp, err := reg.WhoAmI(cmd.Context(), token)
+			if err != nil {
+				return err
+			}
+			username := strings.TrimSpace(resp.GetUsername())
+			if username == "" {
+				return fmt.Errorf("whoami returned an empty username")
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), username)
+			return nil
+		},
+	}
+}

--- a/cmd/pinix/invoke.go
+++ b/cmd/pinix/invoke.go
@@ -1,0 +1,178 @@
+// Role:    Explicit invoke subcommand for calling Clip commands
+// Depends: context, encoding/json, fmt, strconv, strings, internal/client, cobra
+// Exports: newInvokeCommand
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/epiral/pinix/internal/client"
+	"github.com/spf13/cobra"
+)
+
+func newInvokeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "invoke <clip> <command> [--key value ...]",
+		Short: "Invoke a Clip command",
+		Long: `Invoke a command on a Clip registered with the Hub.
+
+Arguments after <clip> <command> are passed as key-value input:
+  pinix invoke todo add --title "Buy milk"
+  pinix invoke search query --q "AI agents"
+
+Flags --server, --auth-token, and --clip-token must come before <clip>.`,
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			for _, arg := range args {
+				if arg == "--help" || arg == "-h" {
+					return cmd.Help()
+				}
+			}
+			return runInvoke(args)
+		},
+	}
+	return cmd
+}
+
+func runInvoke(args []string) error {
+	globals, rest := splitInvokeArgs(args)
+	serverURL, hubToken, clipToken := parseInvokeFlags(globals)
+
+	if len(rest) < 2 {
+		return fmt.Errorf("usage: pinix invoke <clip> <command> [--key value ...]")
+	}
+
+	clipName := rest[0]
+	command := rest[1]
+	input, err := parseInvokeInput(rest[2:])
+	if err != nil {
+		return err
+	}
+
+	cli, err := client.New(serverURL)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	result, err := cli.Invoke(ctx, clipName, command, input, clipToken, hubToken)
+	if err != nil {
+		return err
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	if result[0] == '"' {
+		var value string
+		if err := json.Unmarshal(result, &value); err == nil {
+			fmt.Println(value)
+			return nil
+		}
+	}
+	fmt.Println(string(result))
+	return nil
+}
+
+// splitInvokeArgs separates global flags (--server, --auth-token, --clip-token)
+// from the clip command arguments.
+func splitInvokeArgs(args []string) ([]string, []string) {
+	globals := make([]string, 0, len(args))
+	i := 0
+	for i < len(args) {
+		arg := args[i]
+		if arg == "--" {
+			return globals, args[i+1:]
+		}
+		if !strings.HasPrefix(arg, "-") {
+			return globals, args[i:]
+		}
+		globals = append(globals, arg)
+		if arg == "--server" || arg == "--auth-token" || arg == "--clip-token" {
+			if i+1 < len(args) {
+				globals = append(globals, args[i+1])
+				i += 2
+				continue
+			}
+		}
+		i++
+	}
+	return globals, nil
+}
+
+func parseInvokeFlags(globals []string) (serverURL, hubToken, clipToken string) {
+	serverURL = defaultHubURL()
+	hubToken = defaultHubToken()
+	for i := 0; i < len(globals); i++ {
+		switch globals[i] {
+		case "--server":
+			if i+1 < len(globals) {
+				serverURL = globals[i+1]
+				i++
+			}
+		case "--auth-token":
+			if i+1 < len(globals) {
+				hubToken = globals[i+1]
+				i++
+			}
+		case "--clip-token":
+			if i+1 < len(globals) {
+				clipToken = globals[i+1]
+				i++
+			}
+		}
+	}
+	return
+}
+
+func parseInvokeInput(args []string) (json.RawMessage, error) {
+	if len(args) == 0 {
+		return json.RawMessage(`{}`), nil
+	}
+	input := make(map[string]any)
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if !strings.HasPrefix(arg, "--") {
+			return nil, fmt.Errorf("unexpected argument %q; expected --key value", arg)
+		}
+		key := strings.TrimPrefix(arg, "--")
+		if key == "" {
+			return nil, fmt.Errorf("invalid empty option")
+		}
+		value := "true"
+		if strings.Contains(key, "=") {
+			parts := strings.SplitN(key, "=", 2)
+			key = parts[0]
+			value = parts[1]
+		} else if i+1 < len(args) && !strings.HasPrefix(args[i+1], "--") {
+			i++
+			value = args[i]
+		}
+		input[key] = coerceValue(value)
+	}
+	data, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("marshal invoke input: %w", err)
+	}
+	return data, nil
+}
+
+func coerceValue(value string) any {
+	if value == "true" {
+		return true
+	}
+	if value == "false" {
+		return false
+	}
+	if number, err := strconv.ParseInt(value, 10, 64); err == nil {
+		return number
+	}
+	if number, err := strconv.ParseFloat(value, 64); err == nil {
+		return number
+	}
+	return value
+}

--- a/cmd/pinix/main.go
+++ b/cmd/pinix/main.go
@@ -1,17 +1,15 @@
-// Role:    pinix CLI entrypoint for HubService-backed Clip management and invocation
-// Depends: encoding/json, fmt, os, path/filepath, strconv, strings, internal/client, pinix v2, cobra
+// Role:    pinix CLI entrypoint — routes to invoke, hub, registry, and config subcommands
+// Depends: encoding/json, fmt, os, path/filepath, sort, strings, internal/client, pinix v2, cobra
 // Exports: main
 
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 
 	pinixv2 "github.com/epiral/pinix/gen/go/pinix/v2"
@@ -30,143 +28,25 @@ func main() {
 }
 
 func execute() error {
-	known := map[string]struct{}{
-		"add":        {},
-		"mcp":        {},
-		"remove":     {},
-		"list":       {},
-		"register":   {},
-		"login":      {},
-		"logout":     {},
-		"whoami":     {},
-		"bind":       {},
-		"unbind":     {},
-		"bindings":   {},
-		"search":     {},
-		"publish":    {},
-		"info":       {},
-		"config":     {},
-		"update":     {},
-		"dist-tag":   {},
-		"logs":       {},
-		"help":       {},
-		"completion": {},
-	}
-
-	globals, rest := splitGlobalArgs(os.Args[1:])
-	if len(rest) > 0 {
-		if _, ok := known[rest[0]]; !ok {
-			return executeInvoke(globals, rest)
-		}
-	}
-
 	cmd := newRootCommand()
 	cmd.SetArgs(os.Args[1:])
 	return cmd.Execute()
 }
 
-// executeInvoke bypasses cobra to avoid flag interception. Global flags
-// (--server, --auth-token, --clip-token) are already extracted by
-// splitGlobalArgs; everything in rest belongs to the clip command.
-func executeInvoke(globals, rest []string) error {
-	if len(rest) < 2 {
-		return fmt.Errorf("usage: pinix [flags] <clip> <command> [--key value ...]")
-	}
-
-	serverURL, hubToken, clipToken := parseGlobalFlags(globals)
-
-	clipName := rest[0]
-	command := rest[1]
-	invokeArgs := rest[2:]
-
-	input, err := parseInvokeInput(invokeArgs)
-	if err != nil {
-		return err
-	}
-
-	cli, err := client.New(serverURL)
-	if err != nil {
-		return err
-	}
-
-	ctx := context.Background()
-	result, err := cli.Invoke(ctx, clipName, command, input, clipToken, hubToken)
-	if err != nil {
-		return err
-	}
-	if len(result) == 0 {
-		return nil
-	}
-	if result[0] == '"' {
-		var value string
-		if err := json.Unmarshal(result, &value); err == nil {
-			fmt.Println(value)
-			return nil
-		}
-	}
-	fmt.Println(string(result))
-	return nil
-}
-
-// parseGlobalFlags extracts --server, --auth-token, and --clip-token values
-// from the globals slice produced by splitGlobalArgs.
-func parseGlobalFlags(globals []string) (serverURL, hubToken, clipToken string) {
-	serverURL = client.DefaultServerURL()
-	hubToken = os.Getenv("PINIX_TOKEN")
-	for i := 0; i < len(globals); i++ {
-		switch globals[i] {
-		case "--server":
-			if i+1 < len(globals) {
-				serverURL = globals[i+1]
-				i++
-			}
-		case "--auth-token":
-			if i+1 < len(globals) {
-				hubToken = globals[i+1]
-				i++
-			}
-		case "--clip-token":
-			if i+1 < len(globals) {
-				clipToken = globals[i+1]
-				i++
-			}
-		}
-	}
-	return
-}
-
 func newRootCommand() *cobra.Command {
-	var serverURL string
-	var hubToken string
-
 	rootCmd := &cobra.Command{
 		Use:           "pinix",
-		Short:         "Pinix CLI for managing Clips through pinixd HubService",
+		Short:         "Pinix CLI for managing Clips and invoking commands",
 		Version:       version,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	rootCmd.PersistentFlags().StringVar(&serverURL, "server", client.DefaultServerURL(), "pinixd HubService base URL")
-	rootCmd.PersistentFlags().StringVar(&hubToken, "auth-token", os.Getenv("PINIX_TOKEN"), "hub auth token for protected add/remove operations")
 
-	rootCmd.AddCommand(newAddCommand(&serverURL, &hubToken))
-	rootCmd.AddCommand(newMCPCommand(&serverURL, &hubToken))
-	rootCmd.AddCommand(newRemoveCommand(&serverURL, &hubToken))
-	rootCmd.AddCommand(newListCommand(&serverURL, &hubToken))
-	rootCmd.AddCommand(newRegisterCommand())
-	rootCmd.AddCommand(newLoginCommand())
-	rootCmd.AddCommand(newLogoutCommand())
-	rootCmd.AddCommand(newWhoAmICommand())
-	rootCmd.AddCommand(newBindCommand(&serverURL, &hubToken))
-	rootCmd.AddCommand(newUnbindCommand(&serverURL, &hubToken))
-	rootCmd.AddCommand(newBindingsCommand(&serverURL, &hubToken))
-	rootCmd.AddCommand(newSearchCommand())
-	rootCmd.AddCommand(newPublishCommand())
-	rootCmd.AddCommand(newInfoCommand(&serverURL, &hubToken))
-	rootCmd.AddCommand(newUpdateCommand(&serverURL, &hubToken))
+	rootCmd.AddCommand(newInvokeCommand())
+	rootCmd.AddCommand(newHubCommand())
+	rootCmd.AddCommand(newRegistryGroupCommand())
 	rootCmd.AddCommand(newConfigCommand())
-	rootCmd.AddCommand(newDistTagCommand())
-	rootCmd.AddCommand(newLogsCommand())
+
 	return rootCmd
 }
 
@@ -435,78 +315,6 @@ func clipCommandNames(clip *pinixv2.ClipInfo) []string {
 		result = append(result, command.GetName())
 	}
 	return result
-}
-
-func splitGlobalArgs(args []string) ([]string, []string) {
-	globals := make([]string, 0, len(args))
-	i := 0
-	for i < len(args) {
-		arg := args[i]
-		if arg == "--" {
-			return globals, args[i+1:]
-		}
-		if !strings.HasPrefix(arg, "-") {
-			return globals, args[i:]
-		}
-		globals = append(globals, arg)
-		if arg == "--server" || arg == "--auth-token" || arg == "--clip-token" {
-			if i+1 < len(args) {
-				globals = append(globals, args[i+1])
-				i += 2
-				continue
-			}
-		}
-		i++
-	}
-	return globals, nil
-}
-
-func parseInvokeInput(args []string) (json.RawMessage, error) {
-	if len(args) == 0 {
-		return json.RawMessage(`{}`), nil
-	}
-	input := make(map[string]any)
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if !strings.HasPrefix(arg, "--") {
-			return nil, fmt.Errorf("unexpected argument %q; expected --key value", arg)
-		}
-		key := strings.TrimPrefix(arg, "--")
-		if key == "" {
-			return nil, fmt.Errorf("invalid empty option")
-		}
-		value := "true"
-		if strings.Contains(key, "=") {
-			parts := strings.SplitN(key, "=", 2)
-			key = parts[0]
-			value = parts[1]
-		} else if i+1 < len(args) && !strings.HasPrefix(args[i+1], "--") {
-			i++
-			value = args[i]
-		}
-		input[key] = coerceValue(value)
-	}
-	data, err := json.Marshal(input)
-	if err != nil {
-		return nil, fmt.Errorf("marshal invoke input: %w", err)
-	}
-	return data, nil
-}
-
-func coerceValue(value string) any {
-	if value == "true" {
-		return true
-	}
-	if value == "false" {
-		return false
-	}
-	if number, err := strconv.ParseInt(value, 10, 64); err == nil {
-		return number
-	}
-	if number, err := strconv.ParseFloat(value, 64); err == nil {
-		return number
-	}
-	return value
 }
 
 func firstNonEmpty(values ...string) string {

--- a/cmd/pinix/registry_cmd.go
+++ b/cmd/pinix/registry_cmd.go
@@ -1,0 +1,22 @@
+// Role:    Registry subcommand group — manage Pinix Registry packages
+// Depends: cobra
+// Exports: newRegistryGroupCommand
+
+package main
+
+import "github.com/spf13/cobra"
+
+func newRegistryGroupCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "registry",
+		Short: "Manage Pinix Registry packages",
+	}
+	cmd.AddCommand(newRegisterCommand())
+	cmd.AddCommand(newLoginCommand())
+	cmd.AddCommand(newLogoutCommand())
+	cmd.AddCommand(newWhoAmICommand())
+	cmd.AddCommand(newSearchCommand())
+	cmd.AddCommand(newPublishCommand())
+	cmd.AddCommand(newDistTagCommand())
+	return cmd
+}


### PR DESCRIPTION
## Summary

- 将扁平命令结构重构为 `hub`/`registry`/`invoke` 三个子命令组
- 新增 `pinix hub login/logout/whoami`，token 存入 `client.json`
- 隐式 invoke (`pinix <clip> <command>`) 改为显式 `pinix invoke <clip> <command>`
- Config fallback 链：Hub URL (PID file → config → localhost)，Hub token (env → config)
- 移除 `known` map 白名单 hack，全部走 cobra 路由

## 命令对照

| 旧 | 新 |
|---|---|
| `pinix todo list` | `pinix invoke todo list` |
| `pinix list` | `pinix hub list` |
| `pinix add` | `pinix hub add` |
| `pinix login` | `pinix registry login` |
| `pinix publish` | `pinix registry publish` |
| (无) | `pinix hub login` |

## Test plan

- [x] `go build ./cmd/pinix/` + `go build ./cmd/pinixd/` 编译通过
- [x] `go vet ./...` 无警告
- [x] `go test ./...` 全部通过
- [x] `pinix --help` / `pinix hub --help` / `pinix registry --help` / `pinix invoke --help` 输出正确
- [ ] `pinix hub login --server https://hub.pinix.ai` 端到端验证
- [ ] `pinix invoke todo list` 端到端验证

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)