### PR TITLE
feat: pinix invoke sub-commands + hub info grouping

### DIFF
--- a/cmd/pinix/invoke.go
+++ b/cmd/pinix/invoke.go
@@ -19,13 +19,13 @@ import (
 
 func newInvokeCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "invoke <clip> <command> [--key value ...]",
+		Use:   "invoke <clip> <command> [subcommand] [--key value ...]",
 		Short: "Invoke a Clip command",
 		Long: `Invoke a command on a Clip registered with the Hub.
 
-Arguments after <clip> <command> are passed as key-value input:
+Arguments after <clip> are the command path (supports sub-commands):
   pinix invoke todo add --title "Buy milk"
-  pinix invoke search query --q "AI agents"
+  pinix invoke memex schema list --topLevel true
 
 Flags --server, --auth-token, and --clip-token must come before <clip>.`,
 		DisableFlagParsing: true,
@@ -50,8 +50,11 @@ func runInvoke(args []string) error {
 	}
 
 	clipName := rest[0]
-	command := rest[1]
-	input, err := parseInvokeInput(rest[2:])
+	command, flagArgs := parseCommandPath(rest[1:])
+	if command == "" {
+		return fmt.Errorf("usage: pinix invoke <clip> <command> [--key value ...]")
+	}
+	input, err := parseInvokeInput(flagArgs)
 	if err != nil {
 		return err
 	}
@@ -148,6 +151,20 @@ func parseInvokeFlags(globals []string) (serverURL, hubToken, clipToken string) 
 		}
 	}
 	return
+}
+
+// parseCommandPath extracts the command name from args.
+// Non-flag tokens (before the first --flag) are joined with spaces to form the command.
+// Example: ["schema", "list", "--type", "meeting"] → ("schema list", ["--type", "meeting"])
+func parseCommandPath(args []string) (string, []string) {
+	var parts []string
+	for i, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			return strings.Join(parts, " "), args[i:]
+		}
+		parts = append(parts, arg)
+	}
+	return strings.Join(parts, " "), nil
 }
 
 func parseInvokeInput(args []string) (json.RawMessage, error) {

--- a/cmd/pinix/main.go
+++ b/cmd/pinix/main.go
@@ -202,41 +202,78 @@ func printManifest(clipName string, m *pinixv2.ClipManifest) {
 		}
 	}
 
-	fmt.Println()
-	fmt.Println("  Commands:")
+	// Separate top-level commands from sub-commands (names containing spaces)
+	groups := make(map[string][]*pinixv2.CommandInfo) // group prefix → sub-commands
+	var topLevel []*pinixv2.CommandInfo
 	for _, c := range sorted {
 		name := c.GetName()
-		desc := strings.TrimSpace(c.GetDescription())
-		fmt.Printf("    %-*s   %s\n", maxCmdLen, name, desc)
-
-		// Parse input schema to show parameters
-		params := parseSchemaProperties(c.GetInput())
-		if len(params) == 0 {
-			continue
+		if idx := strings.Index(name, " "); idx > 0 {
+			prefix := name[:idx]
+			groups[prefix] = append(groups[prefix], c)
+		} else {
+			topLevel = append(topLevel, c)
 		}
+	}
 
-		// Compute max param display width for alignment
-		maxParamLen := 0
-		for _, p := range params {
-			display := "--" + p.name + " " + p.typ
-			if p.required {
-				display += " (required)"
-			}
-			if len(display) > maxParamLen {
-				maxParamLen = len(display)
-			}
+	fmt.Println()
+	fmt.Println("  Commands:")
+
+	// Print top-level commands first
+	for _, c := range topLevel {
+		printCommandInfo(c, maxCmdLen, "    ")
+	}
+
+	// Print groups with sub-commands
+	groupNames := make([]string, 0, len(groups))
+	for name := range groups {
+		groupNames = append(groupNames, name)
+	}
+	sort.Strings(groupNames)
+	for _, groupName := range groupNames {
+		cmds := groups[groupName]
+		fmt.Printf("    %s\n", groupName)
+		for _, c := range cmds {
+			subName := strings.TrimPrefix(c.GetName(), groupName+" ")
+			desc := strings.TrimSpace(c.GetDescription())
+			fmt.Printf("      %-*s   %s\n", maxCmdLen-2, subName, desc)
+			printCommandParams(c, "        ")
 		}
+	}
+}
 
-		for _, p := range params {
-			display := "--" + p.name + " " + p.typ
-			if p.required {
-				display += " (required)"
-			}
-			if p.description != "" {
-				fmt.Printf("      %-*s    %s\n", maxParamLen, display, p.description)
-			} else {
-				fmt.Printf("      %s\n", display)
-			}
+func printCommandInfo(c *pinixv2.CommandInfo, maxCmdLen int, indent string) {
+	name := c.GetName()
+	desc := strings.TrimSpace(c.GetDescription())
+	fmt.Printf("%s%-*s   %s\n", indent, maxCmdLen, name, desc)
+	printCommandParams(c, indent+"  ")
+}
+
+func printCommandParams(c *pinixv2.CommandInfo, indent string) {
+	params := parseSchemaProperties(c.GetInput())
+	if len(params) == 0 {
+		return
+	}
+
+	maxParamLen := 0
+	for _, p := range params {
+		display := "--" + p.name + " " + p.typ
+		if p.required {
+			display += " (required)"
+		}
+		if len(display) > maxParamLen {
+			maxParamLen = len(display)
+		}
+	}
+
+	for _, p := range params {
+		display := "--" + p.name + " " + p.typ
+		if p.required {
+			display += " (required)"
+		}
+		if p.description != "" {
+			fmt.Printf("%s%-*s    %s\n", indent, maxParamLen, display, p.description)
+		} else {
+			fmt.Printf("%s%s\n", indent, display)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- `pinix invoke` now supports multi-word commands: `pinix invoke memex schema list --type meeting`
- Non-flag tokens after clip name are joined with spaces to form the command path
- `hub info` detects space-separated command names and displays them grouped under parent prefix
- Depends on epiral/pinixai-core#28 for the `commandGroup()` API

## Test plan

- [x] `go build ./cmd/pinix/` compiles
- [x] Backward compatible: single-word commands work unchanged
- [ ] E2E: `pinix invoke <clip> <group> <sub> --args` routes correctly
- [ ] E2E: `pinix hub info <clip>` shows grouped display

🤖 Generated with [Claude Code](https://claude.com/claude-code)