### PR TITLE
feat(data): per-clip file namespace with pinix data CLI

### DIFF
--- a/cmd/pinix/data.go
+++ b/cmd/pinix/data.go
@@ -1,0 +1,262 @@
+// Role:    CLI data subcommand for Clip Data file I/O operations
+// Depends: context, encoding/base64, encoding/json, fmt, os, strings, internal/client, cobra
+// Exports: newDataCommand
+
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/epiral/pinix/internal/client"
+	"github.com/spf13/cobra"
+)
+
+func newDataCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "data <clip> <operation> [path] [flags]",
+		Short: "Manage Clip data files",
+		Long: `Perform file I/O operations on a Clip's data namespace.
+
+Operations:
+  read <path>              Read a file (raw bytes to stdout)
+  write <path> --content   Write a file
+  list [path]              List directory entries
+  delete <path>            Delete a file
+  stat <path>              Show file metadata
+
+Examples:
+  pinix data browser read screenshots/test.png > test.png
+  pinix data browser write screenshots/test.png --content <b64> --encoding base64
+  pinix data browser list screenshots/
+  pinix data browser delete screenshots/test.png
+  pinix data browser stat screenshots/test.png`,
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			for _, arg := range args {
+				if arg == "--help" || arg == "-h" {
+					return cmd.Help()
+				}
+			}
+			return runData(args)
+		},
+	}
+	return cmd
+}
+
+func runData(args []string) error {
+	globals, rest := splitDataArgs(args)
+	serverURL, hubToken, clipToken := parseDataFlags(globals)
+
+	if len(rest) < 2 {
+		return fmt.Errorf("usage: pinix data <clip> <operation> [path] [flags]")
+	}
+
+	clipName := rest[0]
+	operation := strings.ToLower(rest[1])
+
+	var dataPath string
+	var flagArgs []string
+
+	switch operation {
+	case "read", "write", "delete", "stat":
+		if len(rest) < 3 {
+			return fmt.Errorf("usage: pinix data <clip> %s <path>", operation)
+		}
+		dataPath = rest[2]
+		flagArgs = rest[3:]
+	case "list":
+		if len(rest) >= 3 && !strings.HasPrefix(rest[2], "-") {
+			dataPath = rest[2]
+			flagArgs = rest[3:]
+		} else {
+			flagArgs = rest[2:]
+		}
+	default:
+		return fmt.Errorf("unsupported operation %q; supported: read, write, list, delete, stat", operation)
+	}
+
+	// Parse operation-specific flags.
+	var contentValue string
+	var encoding string
+	var mimeType string
+	for i := 0; i < len(flagArgs); i++ {
+		switch flagArgs[i] {
+		case "--content":
+			if i+1 < len(flagArgs) {
+				i++
+				contentValue = flagArgs[i]
+			}
+		case "--encoding":
+			if i+1 < len(flagArgs) {
+				i++
+				encoding = flagArgs[i]
+			}
+		case "--mime":
+			if i+1 < len(flagArgs) {
+				i++
+				mimeType = flagArgs[i]
+			}
+		default:
+			if strings.HasPrefix(flagArgs[i], "--content=") {
+				contentValue = strings.TrimPrefix(flagArgs[i], "--content=")
+			} else if strings.HasPrefix(flagArgs[i], "--encoding=") {
+				encoding = strings.TrimPrefix(flagArgs[i], "--encoding=")
+			} else if strings.HasPrefix(flagArgs[i], "--mime=") {
+				mimeType = strings.TrimPrefix(flagArgs[i], "--mime=")
+			} else {
+				return fmt.Errorf("unexpected argument %q", flagArgs[i])
+			}
+		}
+	}
+
+	// Prepare content bytes for write.
+	var content []byte
+	if operation == "write" {
+		if contentValue == "" {
+			return fmt.Errorf("--content is required for write")
+		}
+		switch strings.ToLower(encoding) {
+		case "base64":
+			decoded, err := base64.StdEncoding.DecodeString(contentValue)
+			if err != nil {
+				return fmt.Errorf("decode base64 content: %w", err)
+			}
+			content = decoded
+		case "", "utf-8", "utf8", "text":
+			content = []byte(contentValue)
+		default:
+			return fmt.Errorf("unsupported encoding %q; supported: base64, utf-8", encoding)
+		}
+	}
+
+	cli, err := client.New(serverURL)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	resp, err := cli.Data(ctx, clipName, operation, dataPath, content, mimeType, clipToken, hubToken)
+	if err != nil {
+		return err
+	}
+
+	// Check for embedded error.
+	if resp.GetError() != nil {
+		return fmt.Errorf("%s (%s)", resp.GetError().GetMessage(), resp.GetError().GetCode())
+	}
+
+	// Format output based on operation.
+	switch operation {
+	case "read":
+		// Output raw bytes to stdout (pipe-friendly).
+		_, err := os.Stdout.Write(resp.GetContent())
+		return err
+	case "write":
+		out := map[string]any{
+			"uri": resp.GetUri(),
+		}
+		return writeJSON(out)
+	case "list":
+		entries := make([]map[string]any, 0, len(resp.GetEntries()))
+		for _, entry := range resp.GetEntries() {
+			e := map[string]any{
+				"name": entry.GetName(),
+				"path": entry.GetPath(),
+				"type": entry.GetType(),
+			}
+			if entry.GetType() == "file" {
+				e["size"] = entry.GetSize()
+				if entry.GetMime() != "" {
+					e["mime"] = entry.GetMime()
+				}
+			}
+			entries = append(entries, e)
+		}
+		return writeJSON(entries)
+	case "delete":
+		out := map[string]any{
+			"deleted": resp.GetUri(),
+		}
+		return writeJSON(out)
+	case "stat":
+		stat := resp.GetStat()
+		if stat == nil {
+			return fmt.Errorf("no stat information returned")
+		}
+		out := map[string]any{
+			"size":     stat.GetSize(),
+			"mime":     stat.GetMime(),
+			"modified": stat.GetModified(),
+		}
+		return writeJSON(out)
+	}
+	return nil
+}
+
+func writeJSON(v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+// splitDataArgs separates global flags (--server, --auth-token, --clip-token)
+// from the data command arguments. Same logic as splitInvokeArgs.
+func splitDataArgs(args []string) ([]string, []string) {
+	globals := make([]string, 0, len(args))
+	i := 0
+	for i < len(args) {
+		arg := args[i]
+		if arg == "--" {
+			return globals, args[i+1:]
+		}
+		if !strings.HasPrefix(arg, "-") {
+			return globals, args[i:]
+		}
+		// Only consume known global flags; stop at the first positional arg.
+		if arg == "--server" || arg == "--auth-token" || arg == "--clip-token" {
+			globals = append(globals, arg)
+			if i+1 < len(args) {
+				globals = append(globals, args[i+1])
+				i += 2
+				continue
+			}
+		}
+		// Unknown flags before first positional — treat as global.
+		globals = append(globals, arg)
+		i++
+	}
+	return globals, nil
+}
+
+func parseDataFlags(globals []string) (serverURL, hubToken, clipToken string) {
+	serverURL = defaultHubURL()
+	hubToken = defaultHubToken()
+	for i := 0; i < len(globals); i++ {
+		switch globals[i] {
+		case "--server":
+			if i+1 < len(globals) {
+				serverURL = globals[i+1]
+				i++
+			}
+		case "--auth-token":
+			if i+1 < len(globals) {
+				hubToken = globals[i+1]
+				i++
+			}
+		case "--clip-token":
+			if i+1 < len(globals) {
+				clipToken = globals[i+1]
+				i++
+			}
+		}
+	}
+	return
+}

--- a/cmd/pinix/main.go
+++ b/cmd/pinix/main.go
@@ -43,6 +43,7 @@ func newRootCommand() *cobra.Command {
 	}
 
 	rootCmd.AddCommand(newInvokeCommand())
+	rootCmd.AddCommand(newDataCommand())
 	rootCmd.AddCommand(newHubCommand())
 	rootCmd.AddCommand(newRegistryGroupCommand())
 	rootCmd.AddCommand(newConfigCommand())

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -166,6 +166,23 @@ func (c *Client) RemoveBinding(ctx context.Context, clipName, slot, hubToken str
 	return err
 }
 
+func (c *Client) Data(ctx context.Context, clipName, operation, path string, content []byte, mimeType, clipToken, hubToken string) (*pinixv2.DataResponse, error) {
+	req := connect.NewRequest(&pinixv2.DataRequest{
+		ClipName:  strings.TrimSpace(clipName),
+		Operation: strings.TrimSpace(operation),
+		Path:      strings.TrimSpace(path),
+		Content:   content,
+		Mime:      strings.TrimSpace(mimeType),
+		ClipToken: strings.TrimSpace(clipToken),
+	})
+	setAuthHeader(req.Header(), hubToken)
+	resp, err := c.hub.Data(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
+}
+
 func (c *Client) Invoke(ctx context.Context, clipName, command string, input json.RawMessage, clipToken, hubToken string) (json.RawMessage, error) {
 	if len(input) == 0 {
 		input = json.RawMessage(`{}`)

--- a/internal/daemon/connect.go
+++ b/internal/daemon/connect.go
@@ -273,6 +273,64 @@ func (h *HubService) InvokeStream(ctx context.Context, stream *connect.BidiStrea
 	return h.invokeStreamProviderClip(ctx, start, stream)
 }
 
+func (h *HubService) Data(ctx context.Context, req *connect.Request[pinixv2.DataRequest]) (*connect.Response[pinixv2.DataResponse], error) {
+	clipName := strings.TrimSpace(req.Msg.GetClipName())
+	if clipName == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("clip_name is required"))
+	}
+	operation := strings.TrimSpace(req.Msg.GetOperation())
+	if operation == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("operation is required"))
+	}
+
+	// Try local clip first — handle file I/O directly.
+	if h.daemon != nil && h.daemon.hasLocalRuntime() {
+		_, ok, err := h.daemon.registry.GetClip(clipName)
+		if err != nil {
+			return nil, connectErrorFromErr(daemonError{Code: "internal", Message: fmt.Sprintf("load clip: %v", err)})
+		}
+		if ok {
+			resp := handleDataOperation(h.daemon.registry, clipName, operation, req.Msg.GetPath(), req.Msg.GetContent(), req.Msg.GetMime())
+			if resp.GetError() != nil {
+				// Return as a successful response with embedded error (like invoke).
+				return connect.NewResponse(resp), nil
+			}
+			return connect.NewResponse(resp), nil
+		}
+	}
+
+	// Fall back to provider-backed clip.
+	if h.daemon.provider == nil || !h.daemon.provider.HasClip(clipName) {
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("clip %q not found", clipName))
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	resp, err := h.dataViaProvider(ctx, clipName, req.Msg)
+	if err != nil {
+		return nil, connectErrorFromErr(err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
+func (h *HubService) dataViaProvider(ctx context.Context, clipName string, req *pinixv2.DataRequest) (*pinixv2.DataResponse, error) {
+	handle, err := h.daemon.provider.OpenData(clipName, req.GetOperation(), req.GetPath(), req.GetContent(), req.GetMime())
+	if err != nil {
+		return nil, err
+	}
+	defer handle.Close()
+
+	event, err := handle.Receive(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if event.err != nil {
+		return &pinixv2.DataResponse{Error: responseErrorToHubError(event.err)}, nil
+	}
+	return event.response, nil
+}
+
 func (h *HubService) AddClip(ctx context.Context, req *connect.Request[pinixv2.AddClipRequest]) (*connect.Response[pinixv2.AddClipResponse], error) {
 	if strings.TrimSpace(req.Msg.GetSource()) == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("source is required"))

--- a/internal/daemon/data.go
+++ b/internal/daemon/data.go
@@ -1,0 +1,254 @@
+// Role:    File I/O handler for Clip Data operations (read, write, list, delete, stat)
+// Depends: fmt, mime, os, path, path/filepath, strings, time
+// Exports: handleDataOperation
+
+package daemon
+
+import (
+	"fmt"
+	"mime"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	pinixv2 "github.com/epiral/pinix/gen/go/pinix/v2"
+)
+
+// handleDataOperation performs a file I/O operation on the clip's data directory.
+// It does not start any clip process — data operations are handled directly by pinixd.
+func handleDataOperation(registry *Registry, clipName, operation, dataPath string, content []byte, mimeType string) *pinixv2.DataResponse {
+	clipName = strings.TrimSpace(clipName)
+	if clipName == "" {
+		return dataErrorResponse("invalid_argument", "clip_name is required")
+	}
+	operation = strings.TrimSpace(strings.ToLower(operation))
+	if operation == "" {
+		return dataErrorResponse("invalid_argument", "operation is required")
+	}
+
+	// Validate the path to prevent directory traversal.
+	dataPath = strings.TrimSpace(dataPath)
+	if err := validateDataPath(dataPath, operation); err != nil {
+		return dataErrorResponse("invalid_argument", err.Error())
+	}
+
+	dataDir := registry.ClipDataDir(clipName)
+
+	switch operation {
+	case "read":
+		return handleDataRead(dataDir, clipName, dataPath)
+	case "write":
+		return handleDataWrite(dataDir, clipName, dataPath, content, mimeType)
+	case "list":
+		return handleDataList(dataDir, clipName, dataPath)
+	case "delete":
+		return handleDataDelete(dataDir, clipName, dataPath)
+	case "stat":
+		return handleDataStat(dataDir, clipName, dataPath)
+	default:
+		return dataErrorResponse("invalid_argument", fmt.Sprintf("unsupported operation %q; supported: read, write, list, delete, stat", operation))
+	}
+}
+
+func handleDataRead(dataDir, clipName, dataPath string) *pinixv2.DataResponse {
+	fullPath := filepath.Join(dataDir, filepath.FromSlash(dataPath))
+	data, err := os.ReadFile(fullPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return dataErrorResponse("not_found", fmt.Sprintf("file %q not found in clip %q", dataPath, clipName))
+		}
+		return dataErrorResponse("internal", fmt.Sprintf("read file: %v", err))
+	}
+	return &pinixv2.DataResponse{Content: data}
+}
+
+func handleDataWrite(dataDir, clipName, dataPath string, content []byte, mimeType string) *pinixv2.DataResponse {
+	fullPath := filepath.Join(dataDir, filepath.FromSlash(dataPath))
+
+	// Auto-create parent directories.
+	dir := filepath.Dir(fullPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return dataErrorResponse("internal", fmt.Sprintf("create directory: %v", err))
+	}
+
+	if err := os.WriteFile(fullPath, content, 0o644); err != nil {
+		return dataErrorResponse("internal", fmt.Sprintf("write file: %v", err))
+	}
+
+	uri := fmt.Sprintf("pinix://%s/%s", clipName, dataPath)
+	return &pinixv2.DataResponse{Uri: uri}
+}
+
+func handleDataList(dataDir, clipName, dataPath string) *pinixv2.DataResponse {
+	listPath := dataDir
+	if dataPath != "" {
+		listPath = filepath.Join(dataDir, filepath.FromSlash(dataPath))
+	}
+
+	entries, err := os.ReadDir(listPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Return empty list for nonexistent directories (not an error).
+			return &pinixv2.DataResponse{Entries: []*pinixv2.DataEntry{}}
+		}
+		return dataErrorResponse("internal", fmt.Sprintf("list directory: %v", err))
+	}
+
+	result := make([]*pinixv2.DataEntry, 0, len(entries))
+	for _, entry := range entries {
+		entryType := "file"
+		if entry.IsDir() {
+			entryType = "directory"
+		}
+
+		entryPath := path.Join(dataPath, entry.Name())
+		uri := fmt.Sprintf("pinix://%s/%s", clipName, entryPath)
+
+		var size int64
+		var entryMime string
+		if info, err := entry.Info(); err == nil {
+			size = info.Size()
+		}
+		if !entry.IsDir() {
+			entryMime = mimeFromExtension(entry.Name())
+		}
+
+		result = append(result, &pinixv2.DataEntry{
+			Name: entry.Name(),
+			Path: uri,
+			Type: entryType,
+			Size: size,
+			Mime: entryMime,
+		})
+	}
+	return &pinixv2.DataResponse{Entries: result}
+}
+
+func handleDataDelete(dataDir, clipName, dataPath string) *pinixv2.DataResponse {
+	fullPath := filepath.Join(dataDir, filepath.FromSlash(dataPath))
+	if _, err := os.Stat(fullPath); err != nil {
+		if os.IsNotExist(err) {
+			return dataErrorResponse("not_found", fmt.Sprintf("file %q not found in clip %q", dataPath, clipName))
+		}
+		return dataErrorResponse("internal", fmt.Sprintf("stat file: %v", err))
+	}
+
+	if err := os.Remove(fullPath); err != nil {
+		return dataErrorResponse("internal", fmt.Sprintf("delete file: %v", err))
+	}
+
+	uri := fmt.Sprintf("pinix://%s/%s", clipName, dataPath)
+	return &pinixv2.DataResponse{Uri: uri}
+}
+
+func handleDataStat(dataDir, clipName, dataPath string) *pinixv2.DataResponse {
+	fullPath := filepath.Join(dataDir, filepath.FromSlash(dataPath))
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return dataErrorResponse("not_found", fmt.Sprintf("file %q not found in clip %q", dataPath, clipName))
+		}
+		return dataErrorResponse("internal", fmt.Sprintf("stat file: %v", err))
+	}
+
+	return &pinixv2.DataResponse{
+		Stat: &pinixv2.DataStat{
+			Size:     info.Size(),
+			Mime:     mimeFromExtension(info.Name()),
+			Modified: info.ModTime().UTC().Format(time.RFC3339),
+		},
+	}
+}
+
+// validateDataPath ensures the path is safe: no absolute paths, no ".." traversal.
+func validateDataPath(dataPath string, operation string) error {
+	if operation == "list" && dataPath == "" {
+		return nil // list root is ok
+	}
+	if dataPath == "" {
+		return fmt.Errorf("path is required")
+	}
+	if filepath.IsAbs(dataPath) {
+		return fmt.Errorf("path must be relative, got %q", dataPath)
+	}
+	// Clean and check for ".." traversal.
+	cleaned := filepath.Clean(filepath.FromSlash(dataPath))
+	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("path %q escapes data directory", dataPath)
+	}
+	return nil
+}
+
+// mimeFromExtension guesses a MIME type from the file extension.
+func mimeFromExtension(name string) string {
+	ext := filepath.Ext(name)
+	if ext == "" {
+		return "application/octet-stream"
+	}
+	mimeType := mime.TypeByExtension(ext)
+	if mimeType == "" {
+		return "application/octet-stream"
+	}
+	return mimeType
+}
+
+func dataErrorResponse(code, message string) *pinixv2.DataResponse {
+	return &pinixv2.DataResponse{
+		Error: &pinixv2.HubError{Code: code, Message: message},
+	}
+}
+
+// dataResponseToResult converts a DataResponse to a DataResult (for provider stream forwarding).
+func dataResponseToResult(requestID string, resp *pinixv2.DataResponse) *pinixv2.DataResult {
+	if resp == nil {
+		return &pinixv2.DataResult{RequestId: requestID}
+	}
+	result := &pinixv2.DataResult{
+		RequestId: requestID,
+		Content:   cloneBytes(resp.GetContent()),
+		Uri:       resp.GetUri(),
+	}
+	if entries := resp.GetEntries(); len(entries) > 0 {
+		result.Entries = make([]*pinixv2.DataEntry, len(entries))
+		copy(result.Entries, entries)
+	}
+	if stat := resp.GetStat(); stat != nil {
+		result.Stat = &pinixv2.DataStat{
+			Size:     stat.GetSize(),
+			Mime:     stat.GetMime(),
+			Modified: stat.GetModified(),
+		}
+	}
+	if hubErr := resp.GetError(); hubErr != nil {
+		result.Error = &pinixv2.HubError{Code: hubErr.GetCode(), Message: hubErr.GetMessage()}
+	}
+	return result
+}
+
+// dataResultToResponse converts a DataResult (from provider stream) to a DataResponse.
+func dataResultToResponse(result *pinixv2.DataResult) *pinixv2.DataResponse {
+	if result == nil {
+		return &pinixv2.DataResponse{}
+	}
+	resp := &pinixv2.DataResponse{
+		Content: cloneBytes(result.GetContent()),
+		Uri:     result.GetUri(),
+	}
+	if entries := result.GetEntries(); len(entries) > 0 {
+		resp.Entries = make([]*pinixv2.DataEntry, len(entries))
+		copy(resp.Entries, entries)
+	}
+	if stat := result.GetStat(); stat != nil {
+		resp.Stat = &pinixv2.DataStat{
+			Size:     stat.GetSize(),
+			Mime:     stat.GetMime(),
+			Modified: stat.GetModified(),
+		}
+	}
+	if hubErr := result.GetError(); hubErr != nil {
+		resp.Error = &pinixv2.HubError{Code: hubErr.GetCode(), Message: hubErr.GetMessage()}
+	}
+	return resp
+}

--- a/internal/daemon/provider.go
+++ b/internal/daemon/provider.go
@@ -60,6 +60,14 @@ type ProviderClipWebHandle struct {
 	closeOnce sync.Once
 }
 
+type ProviderDataHandle struct {
+	session   *providerSession
+	requestID string
+	responses chan providerDataEvent
+
+	closeOnce sync.Once
+}
+
 type providerSession struct {
 	manager     *ProviderManager
 	name        string
@@ -71,6 +79,7 @@ type providerSession struct {
 	pendingMu      sync.Mutex
 	pendingInvokes map[string]chan providerInvokeChunk
 	pendingClipWeb map[string]chan providerClipWebEvent
+	pendingData    map[string]chan providerDataEvent
 
 	closeOnce sync.Once
 	closed    chan struct{}
@@ -106,6 +115,12 @@ type providerClipWebEvent struct {
 	notModified bool
 	err         *ResponseError
 	done        bool
+}
+
+type providerDataEvent struct {
+	response *pinixv2.DataResponse
+	err      *ResponseError
+	done     bool
 }
 
 func NewProviderManager(registry *Registry) *ProviderManager {
@@ -384,6 +399,41 @@ func (m *ProviderManager) OpenClipWeb(clipName, path string, offset, length int6
 	return handle, nil
 }
 
+func (m *ProviderManager) OpenData(clipName, operation, dataPath string, content []byte, mimeType string) (*ProviderDataHandle, error) {
+	clipName = strings.TrimSpace(clipName)
+	if clipName == "" {
+		return nil, daemonError{Code: "invalid_argument", Message: "clip is required"}
+	}
+
+	ref := m.lookupClip(clipName)
+	if ref == nil {
+		return nil, daemonError{Code: "not_found", Message: fmt.Sprintf("clip %q not found", clipName)}
+	}
+
+	handle := &ProviderDataHandle{
+		session:   ref.session,
+		requestID: fmt.Sprintf("req-%d", m.nextID.Add(1)),
+		responses: make(chan providerDataEvent, 1),
+	}
+	if err := ref.session.registerData(handle.requestID, handle.responses); err != nil {
+		return nil, daemonError{Code: "internal", Message: err.Error()}
+	}
+
+	message := &pinixv2.HubMessage{Payload: &pinixv2.HubMessage_DataCommand{DataCommand: &pinixv2.DataCommand{
+		RequestId: handle.requestID,
+		ClipName:  clipName,
+		Operation: strings.TrimSpace(operation),
+		Path:      strings.TrimSpace(dataPath),
+		Content:   cloneBytes(content),
+		Mime:      strings.TrimSpace(mimeType),
+	}}}
+	if err := ref.session.send(message); err != nil {
+		handle.Close()
+		return nil, daemonError{Code: "internal", Message: err.Error()}
+	}
+	return handle, nil
+}
+
 func (m *ProviderManager) Close() error {
 	m.mu.RLock()
 	sessions := make([]*providerSession, 0, len(m.providers))
@@ -444,6 +494,7 @@ func (m *ProviderManager) registerSession(register *pinixv2.RegisterRequest, str
 		stream:         stream,
 		pendingInvokes: make(map[string]chan providerInvokeChunk),
 		pendingClipWeb: make(map[string]chan providerClipWebEvent),
+		pendingData:    make(map[string]chan providerDataEvent),
 		closed:         make(chan struct{}),
 		clips:          make(map[string]*providerClip, len(clips)),
 	}
@@ -616,6 +667,30 @@ func (h *ProviderClipWebHandle) Close() {
 	})
 }
 
+func (h *ProviderDataHandle) Receive(ctx context.Context) (providerDataEvent, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	select {
+	case event := <-h.responses:
+		return event, nil
+	case <-h.session.closed:
+		return providerDataEvent{}, h.session.err()
+	case <-ctx.Done():
+		return providerDataEvent{}, ctx.Err()
+	}
+}
+
+func (h *ProviderDataHandle) Close() {
+	if h == nil || h.session == nil {
+		return
+	}
+	h.closeOnce.Do(func() {
+		h.session.unregisterData(h.requestID)
+	})
+}
+
 func (s *providerSession) readLoop() error {
 	for {
 		message, err := s.stream.Receive()
@@ -639,6 +714,8 @@ func (s *providerSession) readLoop() error {
 			s.handleInvokeResult(payload.InvokeResult)
 		case *pinixv2.ProviderMessage_GetClipWebResult:
 			s.handleClipWebResult(payload.GetClipWebResult)
+		case *pinixv2.ProviderMessage_DataResult:
+			s.handleDataResult(payload.DataResult)
 		case *pinixv2.ProviderMessage_Ping:
 			if err := s.send(&pinixv2.HubMessage{Payload: &pinixv2.HubMessage_Pong{Pong: &pinixv2.Heartbeat{SentAtUnixMs: payload.Ping.GetSentAtUnixMs()}}}); err != nil {
 				s.closeWithError(err)
@@ -716,6 +793,22 @@ func (s *providerSession) handleClipWebResult(message *pinixv2.GetClipWebResult)
 		notModified: message.GetNotModified(),
 		err:         hubErrorToResponseError(message.GetError()),
 		done:        true,
+	})
+}
+
+func (s *providerSession) handleDataResult(message *pinixv2.DataResult) {
+	if message == nil {
+		return
+	}
+	resp := dataResultToResponse(message)
+	var respErr *ResponseError
+	if hubErr := message.GetError(); hubErr != nil {
+		respErr = hubErrorToResponseError(hubErr)
+	}
+	s.dispatchData(strings.TrimSpace(message.GetRequestId()), providerDataEvent{
+		response: resp,
+		err:      respErr,
+		done:     true,
 	})
 }
 
@@ -812,6 +905,44 @@ func (s *providerSession) dispatchClipWeb(requestID string, event providerClipWe
 	}
 }
 
+func (s *providerSession) registerData(requestID string, ch chan providerDataEvent) error {
+	select {
+	case <-s.closed:
+		return s.err()
+	default:
+	}
+
+	s.pendingMu.Lock()
+	defer s.pendingMu.Unlock()
+	if _, exists := s.pendingData[requestID]; exists {
+		return fmt.Errorf("duplicate provider data request id: %s", requestID)
+	}
+	s.pendingData[requestID] = ch
+	return nil
+}
+
+func (s *providerSession) unregisterData(requestID string) {
+	s.pendingMu.Lock()
+	defer s.pendingMu.Unlock()
+	delete(s.pendingData, requestID)
+}
+
+func (s *providerSession) dispatchData(requestID string, event providerDataEvent) {
+	if requestID == "" {
+		return
+	}
+	s.pendingMu.Lock()
+	ch, ok := s.pendingData[requestID]
+	s.pendingMu.Unlock()
+	if !ok {
+		return
+	}
+	select {
+	case ch <- event:
+	default:
+	}
+}
+
 func (s *providerSession) closeWithError(err error) error {
 	s.closeOnce.Do(func() {
 		if err == nil {
@@ -827,8 +958,10 @@ func (s *providerSession) closeWithError(err error) error {
 		s.pendingMu.Lock()
 		pendingInvokes := s.pendingInvokes
 		pendingClipWeb := s.pendingClipWeb
+		pendingData := s.pendingData
 		s.pendingInvokes = make(map[string]chan providerInvokeChunk)
 		s.pendingClipWeb = make(map[string]chan providerClipWebEvent)
+		s.pendingData = make(map[string]chan providerDataEvent)
 		s.pendingMu.Unlock()
 
 		respErr := &ResponseError{Code: "closed", Message: err.Error()}
@@ -842,6 +975,13 @@ func (s *providerSession) closeWithError(err error) error {
 		for id, ch := range pendingClipWeb {
 			select {
 			case ch <- providerClipWebEvent{err: respErr, done: true}:
+			default:
+				_ = id
+			}
+		}
+		for id, ch := range pendingData {
+			select {
+			case ch <- providerDataEvent{err: respErr, done: true}:
 			default:
 				_ = id
 			}

--- a/internal/daemon/runtime_hub.go
+++ b/internal/daemon/runtime_hub.go
@@ -324,6 +324,8 @@ func (c *runtimeHubConnector) runProviderSession(parent context.Context) error {
 			go c.handleInvokeCommand(sessionCtx, stream, message.GetInvokeCommand())
 		case message.GetGetClipWebCommand() != nil:
 			go c.handleGetClipWebCommand(stream, message.GetGetClipWebCommand())
+		case message.GetDataCommand() != nil:
+			go c.handleDataCommand(stream, message.GetDataCommand())
 		case message.GetPong() != nil:
 			continue
 		default:
@@ -603,6 +605,27 @@ func (c *runtimeHubConnector) handleGetClipWebCommand(stream *connect.BidiStream
 
 func (c *runtimeHubConnector) sendClipWebResult(stream *connect.BidiStreamForClient[pinixv2.ProviderMessage, pinixv2.HubMessage], result *pinixv2.GetClipWebResult) error {
 	return c.sendProvider(stream, &pinixv2.ProviderMessage{Payload: &pinixv2.ProviderMessage_GetClipWebResult{GetClipWebResult: result}})
+}
+
+func (c *runtimeHubConnector) handleDataCommand(stream *connect.BidiStreamForClient[pinixv2.ProviderMessage, pinixv2.HubMessage], command *pinixv2.DataCommand) {
+	requestID := strings.TrimSpace(command.GetRequestId())
+	if requestID == "" {
+		return
+	}
+
+	clipName := strings.TrimSpace(command.GetClipName())
+	if clipName == "" {
+		_ = c.sendDataResult(stream, &pinixv2.DataResult{RequestId: requestID, Error: &pinixv2.HubError{Code: "invalid_argument", Message: "clip_name is required"}})
+		return
+	}
+
+	resp := handleDataOperation(c.daemon.registry, clipName, command.GetOperation(), command.GetPath(), command.GetContent(), command.GetMime())
+	result := dataResponseToResult(requestID, resp)
+	_ = c.sendDataResult(stream, result)
+}
+
+func (c *runtimeHubConnector) sendDataResult(stream *connect.BidiStreamForClient[pinixv2.ProviderMessage, pinixv2.HubMessage], result *pinixv2.DataResult) error {
+	return c.sendProvider(stream, &pinixv2.ProviderMessage{Payload: &pinixv2.ProviderMessage_DataResult{DataResult: result}})
 }
 
 func (c *runtimeHubConnector) handleInstallCommand(ctx context.Context, stream *connect.BidiStreamForClient[pinixv2.RuntimeMessage, pinixv2.HubRuntimeMessage], command *pinixv2.InstallCommand) {

--- a/proto/pinix/v2/hub.proto
+++ b/proto/pinix/v2/hub.proto
@@ -30,6 +30,7 @@ service HubService {
   rpc GetClipWeb(GetClipWebRequest) returns (GetClipWebResponse);
   rpc Invoke(InvokeRequest) returns (stream InvokeResponse);
   rpc InvokeStream(stream InvokeStreamMessage) returns (stream InvokeResponse);
+  rpc Data(DataRequest) returns (DataResponse);
   rpc AddClip(AddClipRequest) returns (AddClipResponse);
   rpc RemoveClip(RemoveClipRequest) returns (RemoveClipResponse);
   rpc GetBindings(GetBindingsRequest) returns (GetBindingsResponse);
@@ -121,6 +122,7 @@ message ProviderMessage {
     Heartbeat ping = 5;
     GetClipWebResult get_clip_web_result = 7;
     ClipStatusChanged clip_status_changed = 8;
+    DataResult data_result = 9;
   }
 }
 
@@ -131,6 +133,7 @@ message HubMessage {
     InvokeInput invoke_input = 3;
     Heartbeat pong = 5;
     GetClipWebCommand get_clip_web_command = 6;
+    DataCommand data_command = 7;
   }
 }
 
@@ -370,3 +373,59 @@ message RemoveBindingRequest {
 }
 
 message RemoveBindingResponse {}
+
+// ============================================================
+//  Clip Data — per-clip file namespace
+// ============================================================
+
+// Client → Hub
+message DataRequest {
+  string clip_name = 1;
+  string operation = 2;   // "read" | "write" | "list" | "delete" | "stat"
+  string path = 3;
+  bytes content = 4;      // write only
+  string mime = 5;        // write only
+  string clip_token = 6;
+}
+
+message DataResponse {
+  bytes content = 1;           // read only
+  string uri = 2;              // write returns pinix://{clip}/{path}
+  repeated DataEntry entries = 3; // list only
+  DataStat stat = 4;           // stat only
+  HubError error = 5;
+}
+
+message DataEntry {
+  string name = 1;
+  string path = 2;       // pinix:// URI
+  string type = 3;       // "file" | "directory"
+  int64 size = 4;
+  string mime = 5;
+}
+
+message DataStat {
+  int64 size = 1;
+  string mime = 2;
+  string modified = 3;   // ISO 8601
+}
+
+// Hub → Provider (via ProviderStream)
+message DataCommand {
+  string request_id = 1;
+  string clip_name = 2;
+  string operation = 3;
+  string path = 4;
+  bytes content = 5;
+  string mime = 6;
+}
+
+// Provider → Hub (via ProviderStream)
+message DataResult {
+  string request_id = 1;
+  bytes content = 2;
+  string uri = 3;
+  repeated DataEntry entries = 4;
+  DataStat stat = 5;
+  HubError error = 6;
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 of Clip Data ([RFC #104](https://github.com/epiral/pinix/issues/104)) — per-clip file namespace with `pinix data` CLI.

Each clip gets its own file namespace at `~/.pinix/data/{clip_name}/`, accessible via `pinix data` (parallel to `pinix invoke`). Data operations are handled directly by pinixd without starting clip processes.

### Changes

- **Proto** (`hub.proto`): `Data` RPC + `DataRequest`/`DataResponse` messages + `DataCommand`/`DataResult` in provider stream oneof
- **pinixd** (`data.go`): File I/O handler with path traversal protection, MIME inference, auto-mkdir
- **pinixd** (`connect.go`, `provider.go`, `runtime_hub.go`): Data routing — local-first, falls back to provider stream (same pattern as invoke)
- **CLI** (`data.go`): `pinix data <clip> <operation> [path] [flags]` with read/write/list/delete/stat

### Usage

```bash
pinix data browser write screenshots/test.png --content <b64> --encoding base64
pinix data browser read screenshots/test.png > test.png
pinix data browser list screenshots/
pinix data browser stat screenshots/test.png
pinix data browser delete screenshots/test.png
```

### Backward compatible

All changes are additive — new proto messages, new RPC, new CLI command. Old clients/providers ignore unknown oneof fields. No breaking changes.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [ ] Manual: `pinix data <clip> write/read/list/stat/delete` against local pinixd

Ref #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)