### PR TITLE
feat(cli): non-interactive hub login, config list, auth error hints

### DIFF
--- a/cmd/pinix/config.go
+++ b/cmd/pinix/config.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"text/tabwriter"
 
+	"github.com/epiral/pinix/internal/client"
 	configpkg "github.com/epiral/pinix/internal/config"
 	"github.com/spf13/cobra"
 )
@@ -20,6 +22,7 @@ func newConfigCommand() *cobra.Command {
 	}
 	cmd.AddCommand(newConfigSetCommand())
 	cmd.AddCommand(newConfigGetCommand())
+	cmd.AddCommand(newConfigListCommand())
 	return cmd
 }
 
@@ -85,6 +88,45 @@ func newConfigGetCommand() *cobra.Command {
 				return fmt.Errorf("unknown config key %q; supported keys: registry, hub, hub-token", key)
 			}
 			return nil
+		},
+	}
+}
+
+func newConfigListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all config keys and current values",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := configpkg.ReadClientConfig()
+			if err != nil {
+				return err
+			}
+
+			registry := cfg.Registry
+			if registry == "" {
+				registry = configpkg.DefaultRegistryURL + " (default)"
+			}
+
+			hub := cfg.Hub
+			if hub == "" {
+				hub = client.FallbackServerURL + " (default)"
+			}
+
+			hubToken := "(not set)"
+			if t := strings.TrimSpace(cfg.HubToken); t != "" {
+				if len(t) > 8 {
+					hubToken = t[:8] + "..."
+				} else {
+					hubToken = "***"
+				}
+			}
+
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+			fmt.Fprintf(w, "registry\t%s\n", registry)
+			fmt.Fprintf(w, "hub\t%s\n", hub)
+			fmt.Fprintf(w, "hub-token\t%s\n", hubToken)
+			return w.Flush()
 		},
 	}
 }

--- a/cmd/pinix/hub.go
+++ b/cmd/pinix/hub.go
@@ -5,9 +5,12 @@
 package main
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/epiral/pinix/internal/client"
 	configpkg "github.com/epiral/pinix/internal/config"
@@ -65,6 +68,8 @@ func newHubCommand() *cobra.Command {
 
 func newHubLoginCommand(serverURL *string) *cobra.Command {
 	var registryURL string
+	var username string
+	var password string
 
 	cmd := &cobra.Command{
 		Use:   "login",
@@ -75,15 +80,27 @@ func newHubLoginCommand(serverURL *string) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			prompter := newInteractivePrompter(cmd.InOrStdin(), cmd.ErrOrStderr())
-			username, err := prompter.readRequired("Username", true)
-			if err != nil {
-				return err
+
+			switch {
+			case username != "" && password != "":
+				// non-interactive: both flags provided
+			case username == "" && password == "":
+				if !isStdinTerminal() {
+					return fmt.Errorf("non-interactive mode requires --username and --password flags")
+				}
+				prompter := newInteractivePrompter(cmd.InOrStdin(), cmd.ErrOrStderr())
+				username, err = prompter.readRequired("Username", true)
+				if err != nil {
+					return err
+				}
+				password, err = prompter.readRequired("Password", false)
+				if err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("both --username and --password must be provided together")
 			}
-			password, err := prompter.readRequired("Password", false)
-			if err != nil {
-				return err
-			}
+
 			resp, err := reg.Login(cmd.Context(), username, password)
 			if err != nil {
 				return err
@@ -112,8 +129,18 @@ func newHubLoginCommand(serverURL *string) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&username, "username", "", "Username (for non-interactive login)")
+	cmd.Flags().StringVar(&password, "password", "", "Password (for non-interactive login)")
 	cmd.Flags().StringVar(&registryURL, "registry", "", "Registry URL for authentication (default: from config or https://api.pinix.ai)")
 	return cmd
+}
+
+func isStdinTerminal() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
 }
 
 func newHubLogoutCommand() *cobra.Command {
@@ -139,7 +166,7 @@ func newHubLogoutCommand() *cobra.Command {
 func newHubWhoAmICommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "whoami",
-		Short: "Show the current Hub user",
+		Short: "Show the current Hub user and token status",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := configpkg.ReadClientConfig()
@@ -150,13 +177,23 @@ func newHubWhoAmICommand() *cobra.Command {
 			if token == "" {
 				return fmt.Errorf("not logged in; run \"pinix hub login\"")
 			}
+
+			if exp, err := parseJWTExpiry(token); err == nil {
+				remaining := time.Until(exp)
+				if remaining <= 0 {
+					fmt.Fprintf(cmd.ErrOrStderr(), "warning: token expired %s ago\n", (-remaining).Truncate(time.Minute))
+				} else if remaining < 7*24*time.Hour {
+					fmt.Fprintf(cmd.ErrOrStderr(), "warning: token expires in %s\n", remaining.Truncate(time.Minute))
+				}
+			}
+
 			reg, err := requireRegistryClient("")
 			if err != nil {
 				return err
 			}
 			resp, err := reg.WhoAmI(cmd.Context(), token)
 			if err != nil {
-				return err
+				return wrapAuthError(err)
 			}
 			username := strings.TrimSpace(resp.GetUsername())
 			if username == "" {
@@ -166,4 +203,35 @@ func newHubWhoAmICommand() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func parseJWTExpiry(token string) (time.Time, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return time.Time{}, fmt.Errorf("not a JWT")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return time.Time{}, err
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return time.Time{}, err
+	}
+	if claims.Exp == 0 {
+		return time.Time{}, fmt.Errorf("no exp claim")
+	}
+	return time.Unix(claims.Exp, 0), nil
+}
+
+func wrapAuthError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if client.IsAuthError(err) {
+		return fmt.Errorf("%w\n\nHint: your token may be expired or invalid. Run \"pinix hub login\" to refresh it.", err)
+	}
+	return err
 }

--- a/internal/client/registry.go
+++ b/internal/client/registry.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -410,6 +411,25 @@ func (c *RegistryClient) doJSON(ctx context.Context, method, path string, body i
 	return nil
 }
 
+// RegistryHTTPError represents an API error with HTTP status code preserved.
+type RegistryHTTPError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *RegistryHTTPError) Error() string {
+	return e.Message
+}
+
+// IsAuthError checks whether an error represents an authentication/authorization failure.
+func IsAuthError(err error) bool {
+	var httpErr *RegistryHTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode == 401 || httpErr.StatusCode == 403
+	}
+	return false
+}
+
 func (c *RegistryClient) decodeAPIError(resp *http.Response, action string) error {
 	if resp == nil {
 		return fmt.Errorf("%s: empty response", action)
@@ -423,5 +443,8 @@ func (c *RegistryClient) decodeAPIError(resp *http.Response, action string) erro
 	if message == "" {
 		message = http.StatusText(resp.StatusCode)
 	}
-	return fmt.Errorf("%s: %s", action, message)
+	return &RegistryHTTPError{
+		StatusCode: resp.StatusCode,
+		Message:    fmt.Sprintf("%s: %s", action, message),
+	}
 }


### PR DESCRIPTION
## Summary
- `pinix hub login --username X --password Y` — non-interactive login for Docker/CI (detects non-TTY stdin)
- `pinix config list` — lists all supported config keys with masked values
- Token expiry detection: `whoami` shows JWT expiry warnings, auth errors (401/403) suggest `pinix hub login`
- `RegistryHTTPError` preserves HTTP status code for better error handling

## Test plan
- [x] `pinix config list` — shows registry, hub, hub-token with masked value
- [x] `pinix hub login --help` — shows --username and --password flags
- [x] Piped stdin without flags → error "non-interactive mode requires --username and --password"
- [x] Single flag only → error "both must be provided together"
- [x] `pinix hub login --username yan5xu --password xxx` → logged in successfully
- [x] `pinix hub whoami` → shows username, no warning (token not expired)
- [x] `go build && go vet` pass

Closes #106 (items 2, 3, 5)