### PR TITLE
feat(cli): auto-discover hub URL from pinixd pidfile

### DIFF
--- a/cmd/pinix/hub.go
+++ b/cmd/pinix/hub.go
@@ -14,14 +14,21 @@ import (
 
 	"github.com/epiral/pinix/internal/client"
 	configpkg "github.com/epiral/pinix/internal/config"
+	"github.com/epiral/pinix/internal/pidfile"
 	"github.com/spf13/cobra"
 )
 
-// defaultHubURL resolves the Hub URL from: client.json > fallback (localhost:9000).
+// defaultHubURL resolves the Hub URL from: client.json > pidfile > fallback (localhost:9000).
 func defaultHubURL() string {
 	cfg, err := configpkg.ReadClientConfig()
 	if err == nil && strings.TrimSpace(cfg.Hub) != "" {
 		return strings.TrimSpace(cfg.Hub)
+	}
+	if pf, err := pidfile.ReadPIDFile(); err == nil && pf != nil {
+		if strings.TrimSpace(pf.Hub) != "" {
+			return strings.TrimSpace(pf.Hub)
+		}
+		return fmt.Sprintf("http://127.0.0.1:%d", pf.Port)
 	}
 	return client.FallbackServerURL
 }

--- a/cmd/pinixd/main.go
+++ b/cmd/pinixd/main.go
@@ -116,7 +116,10 @@ func main() {
 	if err := pidfile.CheckExistingPIDFile(port, pidPath); err != nil {
 		exitErr(err)
 	}
-	pidCleanup, err := pidfile.WritePIDFile(port, pidPath)
+	pidCleanup, err := pidfile.WritePIDFile(port, pidfile.WritePIDFileOptions{
+		Hub:        hubURL,
+		CustomPath: pidPath,
+	})
 	if err != nil {
 		exitErr(fmt.Errorf("write pid file: %w", err))
 	}

--- a/internal/pidfile/pidfile.go
+++ b/internal/pidfile/pidfile.go
@@ -17,6 +17,7 @@ import (
 type PIDFile struct {
 	PID       int    `json:"pid"`
 	Port      int    `json:"port"`
+	Hub       string `json:"hub,omitempty"`
 	StartedAt string `json:"startedAt"`
 }
 
@@ -37,15 +38,20 @@ func resolvePIDPath(customPath string) (string, error) {
 	return defaultPIDFilePath()
 }
 
+// WritePIDFileOptions configures WritePIDFile.
+type WritePIDFileOptions struct {
+	Hub        string
+	CustomPath string
+}
+
 // WritePIDFile writes the PID file with current process info.
-// If customPath is provided, uses that path instead of the default.
 // Returns a cleanup function that removes the file.
-func WritePIDFile(port int, customPath ...string) (cleanup func(), err error) {
-	cp := ""
-	if len(customPath) > 0 {
-		cp = customPath[0]
+func WritePIDFile(port int, opts ...WritePIDFileOptions) (cleanup func(), err error) {
+	var o WritePIDFileOptions
+	if len(opts) > 0 {
+		o = opts[0]
 	}
-	path, err := resolvePIDPath(cp)
+	path, err := resolvePIDPath(o.CustomPath)
 	if err != nil {
 		return nil, err
 	}
@@ -58,6 +64,7 @@ func WritePIDFile(port int, customPath ...string) (cleanup func(), err error) {
 	pf := PIDFile{
 		PID:       os.Getpid(),
 		Port:      port,
+		Hub:       o.Hub,
 		StartedAt: time.Now().UTC().Format(time.RFC3339),
 	}
 
@@ -77,14 +84,9 @@ func WritePIDFile(port int, customPath ...string) (cleanup func(), err error) {
 }
 
 // ReadPIDFile reads and validates the PID file.
-// If customPath is provided, uses that path instead of the default.
 // Returns nil, nil if the file doesn't exist or the process is dead (stale file is auto-cleaned).
 func ReadPIDFile(customPath ...string) (*PIDFile, error) {
-	cp := ""
-	if len(customPath) > 0 {
-		cp = customPath[0]
-	}
-	path, err := resolvePIDPath(cp)
+	path, err := resolvePIDPath(firstString(customPath))
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +129,6 @@ func ReadPIDFile(customPath ...string) (*PIDFile, error) {
 }
 
 // CheckExistingPIDFile checks if another pinixd is already running.
-// If customPath is provided, checks that specific PID file.
 // Returns an error if a live process is found.
 func CheckExistingPIDFile(port int, customPath ...string) error {
 	pf, err := ReadPIDFile(customPath...)
@@ -138,4 +139,11 @@ func CheckExistingPIDFile(port int, customPath ...string) error {
 		return nil
 	}
 	return fmt.Errorf("pinixd is already running (pid %d, port %d)", pf.PID, pf.Port)
+}
+
+func firstString(ss []string) string {
+	if len(ss) > 0 {
+		return ss[0]
+	}
+	return ""
 }


### PR DESCRIPTION
## Summary
- pinixd writes hub URL to pidfile in `--hub` mode (`{"pid":…,"port":…,"hub":"https://hub.pinix.ai","startedAt":"…"}`)
- CLI `defaultHubURL()` fallback chain: config → pidfile.hub → `localhost:{pidfile.port}` → `localhost:9000`
- Docker 场景零配置：`pinixd --hub https://hub.pinix.ai` 启动后，`pinix invoke` 自动发现 hub 地址

## Test plan
- [x] `go build ./cmd/pinix/ ./cmd/pinixd/ && go vet ./...` pass
- [ ] Deploy to Mac Mini, verify pidfile contains `hub` field
- [ ] Remove `hub` from config, verify CLI falls back to pidfile

Addresses #106 (item 1)