### PR TITLE
feat(pinixd): auto-connect to Cloud Hub from config when logged in

### DIFF
--- a/cmd/pinixd/main.go
+++ b/cmd/pinixd/main.go
@@ -79,8 +79,10 @@ func main() {
 	if hubToken == "" {
 		hubToken = strings.TrimSpace(os.Getenv("PINIX_HUB_TOKEN"))
 	}
-	if hubToken == "" {
+	autoConnect := false
+	if hubToken == "" && strings.TrimSpace(clientConfig.HubToken) != "" {
 		hubToken = strings.TrimSpace(clientConfig.HubToken)
+		autoConnect = true
 	}
 
 	// Resolve hub: flag > env > config file
@@ -88,9 +90,16 @@ func main() {
 	if hubURL == "" {
 		if v := strings.TrimSpace(os.Getenv("PINIX_HUB")); v != "" {
 			hubURL = v
-		} else {
-			hubURL = strings.TrimSpace(clientConfig.Hub)
+		} else if v := strings.TrimSpace(clientConfig.Hub); v != "" {
+			hubURL = v
+		} else if hubToken != "" {
+			// Have token but no hub URL — default to Cloud Hub
+			hubURL = "https://hub.pinix.ai"
 		}
+	}
+
+	if autoConnect && hubURL != "" {
+		slog.Info("hub: auto-connecting from config", "hub", hubURL)
 	}
 	if hubOnly && hubURL != "" {
 		exitErr(fmt.Errorf("--hub and --hub-only cannot be used together"))


### PR DESCRIPTION
Closes #119

## 改动

pinixd 启动时，如果 `~/.pinix/client.json` 中有 `hub_token`（且 CLI flag 和环境变量都没设置），自动连接 Cloud Hub。

### 优先级

| 来源 | hub_token | hub URL |
|---|---|---|
| CLI flag | `--hub-token` | `--hub` |
| 环境变量 | `PINIX_HUB_TOKEN` | `PINIX_HUB` |
| client.json | `hub_token` | `hub` |
| 默认值 | - | `https://hub.pinix.ai` |

### 效果

```text
pinix login --token $TOKEN --server https://api.pinixai.com
pinixd
→ hub: auto-connecting from config
→ hub: register response accepted=true
```

用户不再需要每次手动传 `--hub` 和 `--hub-token`。

### 改动文件

- `cmd/pinixd/main.go`：+12/-3 行

### 测试

- build/vet/test 通过
- Docker 实测：login → pinixd auto-connect → Cloud Hub registered

### 已知问题

`pinix login` 通过 pinixai.com 登录时，`/auth/whoami` 没有返回 `hub` 字段，导致 config 中 `hub` 为空，pinixd 默认连 `hub.pinix.ai`（海外）。需要后续让 pinixai.com 的 whoami 返回正确的 hub URL，或让 `pinix login` 从 server URL 推导 hub URL。