### PR TITLE
fix: default to pinixai.com + derive hub URL from auth server

### DIFF
--- a/cmd/pinix/auth.go
+++ b/cmd/pinix/auth.go
@@ -63,7 +63,7 @@ func newAuthLoginCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&token, "token", "", "authenticate with an existing token (skips device code flow)")
-	cmd.Flags().StringVar(&server, "server", "", "auth server URL (default: https://api.pinix.ai)")
+	cmd.Flags().StringVar(&server, "server", "", "auth server URL (default: https://api.pinixai.com)")
 	return cmd
 }
 
@@ -137,6 +137,9 @@ func loginWithToken(cmd *cobra.Command, serverURL, token string) error {
 	if hub != "" {
 		cfg.Hub = hub
 	}
+	if cfg.Hub == "" {
+		cfg.Hub = hubURLFromAuthServer(serverURL)
+	}
 	if err := configpkg.WriteClientConfig(cfg); err != nil {
 		return err
 	}
@@ -207,7 +210,7 @@ func loginWithDeviceCode(cmd *cobra.Command, serverURL string) error {
 
 		switch pollResp.Status {
 		case "complete":
-			return saveLoginResult(cmd, pollResp)
+			return saveLoginResult(cmd, serverURL, pollResp)
 		case "expired":
 			return fmt.Errorf("login expired; please try again")
 		case "pending", "authorization_pending":
@@ -222,7 +225,7 @@ func loginWithDeviceCode(cmd *cobra.Command, serverURL string) error {
 }
 
 // saveLoginResult writes the successful login response to config.
-func saveLoginResult(cmd *cobra.Command, resp *devicePollResponse) error {
+func saveLoginResult(cmd *cobra.Command, serverURL string, resp *devicePollResponse) error {
 	cfg, err := configpkg.ReadClientConfig()
 	if err != nil {
 		return err
@@ -247,6 +250,9 @@ func saveLoginResult(cmd *cobra.Command, resp *devicePollResponse) error {
 	}
 	if hub := strings.TrimSpace(resp.Hub); hub != "" {
 		cfg.Hub = hub
+	}
+	if cfg.Hub == "" {
+		cfg.Hub = hubURLFromAuthServer(serverURL)
 	}
 	if err := configpkg.WriteClientConfig(cfg); err != nil {
 		return err
@@ -371,6 +377,22 @@ func decodeAuthError(resp *http.Response, action string) error {
 		return fmt.Errorf("%s: %s", action, body.Error)
 	}
 	return fmt.Errorf("%s: HTTP %d", action, resp.StatusCode)
+}
+
+// hubURLFromAuthServer derives the Hub URL from the auth server URL.
+// e.g. "https://api.pinixai.com" → "https://hub.pinixai.com"
+//
+//	"https://api.pinix.ai" → "https://hub.pinix.ai"
+func hubURLFromAuthServer(serverURL string) string {
+	serverURL = strings.TrimRight(serverURL, "/")
+	if strings.Contains(serverURL, "api.pinixai.com") {
+		return "https://hub.pinixai.com"
+	}
+	if strings.Contains(serverURL, "api.pinix.ai") {
+		return "https://hub.pinix.ai"
+	}
+	// Generic: replace "api." with "hub."
+	return strings.Replace(serverURL, "://api.", "://hub.", 1)
 }
 
 // openBrowser tries to open a URL in the default browser.

--- a/cmd/pinix/hub.go
+++ b/cmd/pinix/hub.go
@@ -138,7 +138,7 @@ func newHubLoginCommand(serverURL *string) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&username, "username", "", "Username (for non-interactive login)")
 	cmd.Flags().StringVar(&password, "password", "", "Password (for non-interactive login)")
-	cmd.Flags().StringVar(&registryURL, "registry", "", "Registry URL for authentication (default: from config or https://api.pinix.ai)")
+	cmd.Flags().StringVar(&registryURL, "registry", "", "Registry URL for authentication (default: from config or https://api.pinixai.com)")
 	return cmd
 }
 

--- a/cmd/pinix/main.go
+++ b/cmd/pinix/main.go
@@ -92,7 +92,7 @@ func newAddCommand(serverURL, hubToken *string) *cobra.Command {
 	cmd.Flags().StringVar(&clipToken, "token", "", "clip token required for invoking this Clip")
 	cmd.Flags().StringVar(&alias, "alias", "", "explicit clip alias")
 	cmd.Flags().StringVar(&provider, "provider", "", "target provider for add/remove operations")
-	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL (default: from config or https://api.pinix.ai)")
+	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL (default: from config or https://api.pinixai.com)")
 	cmd.Flags().StringVar(&localPath, "path", "", "local directory path for local/ sources")
 	return cmd
 }

--- a/cmd/pinix/registry.go
+++ b/cmd/pinix/registry.go
@@ -76,7 +76,7 @@ func newSearchCommand() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL (default: from config or https://api.pinix.ai)")
+	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL (default: from config or https://api.pinixai.com)")
 	cmd.Flags().StringVar(&domain, "domain", "", "filter results by domain")
 	cmd.Flags().StringVar(&packageType, "type", "", "filter results by package type")
 	return cmd
@@ -124,7 +124,7 @@ func newPublishCommand() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL (default: from config or https://api.pinix.ai)")
+	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL (default: from config or https://api.pinixai.com)")
 	cmd.Flags().StringVar(&tag, "tag", "", "dist-tag to publish under")
 	return cmd
 }

--- a/cmd/pinix/registry_auth.go
+++ b/cmd/pinix/registry_auth.go
@@ -69,7 +69,7 @@ func newRegisterCommand() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL (default: from config or https://api.pinix.ai)")
+	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL (default: from config or https://api.pinixai.com)")
 	return cmd
 }
 
@@ -106,7 +106,7 @@ func newLoginCommand() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL (default: from config or https://api.pinix.ai)")
+	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL (default: from config or https://api.pinixai.com)")
 	return cmd
 }
 
@@ -135,7 +135,7 @@ func newLogoutCommand() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL (default: from config or https://api.pinix.ai)")
+	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL (default: from config or https://api.pinixai.com)")
 	return cmd
 }
 
@@ -167,7 +167,7 @@ func newWhoAmICommand() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL (default: from config or https://api.pinix.ai)")
+	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL (default: from config or https://api.pinixai.com)")
 	return cmd
 }
 

--- a/cmd/pinix/update.go
+++ b/cmd/pinix/update.go
@@ -49,7 +49,7 @@ func newUpdateCommand(serverURL, hubToken *string) *cobra.Command {
 			return updateSingleClip(cmd.Context(), cli, clips, args[0], registryURL, version, *hubToken)
 		},
 	}
-	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL (default: from config or https://api.pinix.ai)")
+	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL (default: from config or https://api.pinixai.com)")
 	cmd.Flags().StringVar(&version, "version", "", "update to a specific version instead of latest")
 	cmd.Flags().BoolVar(&all, "all", false, "update all registry-installed clips")
 	return cmd

--- a/cmd/pinixd/main.go
+++ b/cmd/pinixd/main.go
@@ -94,7 +94,7 @@ func main() {
 			hubURL = v
 		} else if hubToken != "" {
 			// Have token but no hub URL — default to Cloud Hub
-			hubURL = "https://hub.pinix.ai"
+			hubURL = "https://hub.pinixai.com"
 		}
 	}
 

--- a/internal/config/client.go
+++ b/internal/config/client.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 )
 
-const DefaultRegistryURL = "https://api.pinix.ai"
-const DefaultAuthServerURL = "https://api.pinix.ai"
+const DefaultRegistryURL = "https://api.pinixai.com"
+const DefaultAuthServerURL = "https://api.pinixai.com"
 
 type UserInfo struct {
 	Username string `json:"username,omitempty"`


### PR DESCRIPTION
## 改动

1. 默认 Registry 和 Auth URL 从 `api.pinix.ai` 改为 `api.pinixai.com`。
2. pinixd 默认 Hub URL 从 `hub.pinix.ai` 改为 `hub.pinixai.com`。
3. `pinix login` 写 config 时，如果 whoami 没返回 hub URL，从 auth server URL 推导：
   - `api.pinixai.com` → `hub.pinixai.com`
   - `api.pinix.ai` → `hub.pinix.ai`
   - 其他 → `api.` 替换为 `hub.`
4. 所有 CLI help text 中的 URL 同步更新。

## 改动文件

- `internal/config/client.go`：DefaultRegistryURL, DefaultAuthServerURL
- `cmd/pinixd/main.go`：默认 hub URL
- `cmd/pinix/auth.go`：新增 hubURLFromAuthServer，loginWithToken 和 saveLoginResult 使用它
- `cmd/pinix/hub.go, main.go, registry.go, registry_auth.go, update.go`：help text URL

## 测试

- build/vet/test 通过