### PR TITLE
docs: rewrite README as Agent Harness landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,110 @@
 # Pinix
 
-Pinix is a Clip runtime and routing Hub: run Bun/TS Clips locally, route Clip-to-Clip calls through a Go Hub, and connect Edge Clips over Connect-RPC.
+**Agent Harness** — an open capability layer for Agents to discover, invoke, compose, and constrain tools.
 
-[![Release](https://img.shields.io/github/v/release/epiral/pinix?color=blue)](https://github.com/epiral/pinix/releases/tag/v2.0.0)
-
-[English](README.md) | [中文](README.zh-CN.md)
-
-## Architecture
+Pinix wraps devices, apps, websites, services, and workflows into **Clips**. Each Clip is a self-contained capability unit that can be called by any Agent, CLI, or MCP client. Some Clips also ship their own Web UI for direct human use.
 
 ```text
-CLI / MCP / Portal
-        |
-        | Connect-RPC
-        v
-+---------------------------+
-| Hub                       |
-| routes by clip name       |
-+-------------+-------------+
-              |
-      +-------+-------+
-      |               |
-      |               | ProviderStream
-      |               v
-      |         Edge Clips / Providers
-      |         (bb-browserd, devices)
-      |
-      v
- pinixd local runtime
-      |
-      | NDJSON IPC v2
-      v
-   Bun/TS Clips
+Human / Agent / CLI
+  -> Hub
+  -> Clips
+  -> device / app / web / SaaS / workflow
 ```
 
 ## Quick Start
 
-1. Install `bun` when you want to run local Clips, then download `pinixd` and `pinix` from the [v2.0.0 release](https://github.com/epiral/pinix/releases/tag/v2.0.0), or build them from source.
-2. Start Pinix in full mode: `./pinixd --port 9000`
-3. Install your first Clip: `./pinix --server http://127.0.0.1:9000 add clip-todo`
-4. Invoke it: `./pinix --server http://127.0.0.1:9000 todo add -- --title "Ship docs"`
-5. Open the Portal at `http://127.0.0.1:9000`, then expose MCP with `./pinix mcp --all --server http://127.0.0.1:9000`
-
-## pinixd Modes
-
 ```bash
-./pinixd --port 9000
-./pinixd --port 9000 --hub-only
-./pinixd --port 9001 --hub http://hub:9000
+# 1. Start Pinix
+pinixd
+
+# 2. Connect to pinix.ai
+pinix login
+
+# 3. Install a Clip
+pinix hub add @pinix/todo
+
+# 4. Use it
+pinix invoke todo add --title "Hello Pinix"
+pinix invoke todo list
+
+# 5. Open Console
+open http://localhost:9000
 ```
 
-- Default mode: Hub + Runtime + Portal.
-- `--hub-only`: Hub + Portal only, without local Clip process management.
-- `--hub`: Runtime only. It connects to an external Hub as a Provider and registers locally managed Clips there.
+After `pinix login`, your local Clips are accessible from any device through pinix.ai Cloud Hub.
+
+## What Happens When You Start Pinix
+
+```text
+pinixd
+  ├── Hub        — routes invoke calls to the right Clip
+  ├── Runtime    — manages local Bun/TS Clip processes
+  ├── Registry   — installs Clips from pinix.ai Registry
+  └── Console    — web UI to manage Clips at localhost:9000
+```
+
+If BB-Browser is installed, it auto-starts a headless Chrome and registers browser capabilities as Edge Clips:
+
+```text
+pinix hub list
+
+  github     RUNNING   trending, repo, search
+  twitter    RUNNING   search, timeline
+  reddit     RUNNING   search, hot
+  todo       RUNNING   add, delete, list
+```
+
+## Clips
+
+Clips are the core abstraction. They provide two key values:
+
+1. **Lower model requirements.** Complex operations are wrapped into deterministic commands. Agents just call them.
+2. **Bounded capabilities.** Agents can only access what Clips expose. Permissions, audit, and testing are built in.
+
+Three types of Clips:
+
+| Type | How it works | Example |
+|---|---|---|
+| **SDK Clip** | Bun/TS app managed by Runtime, installed via `pinix hub add` | todo, review, memex |
+| **Edge Clip** | Native process implementing Provider protocol, auto-registers with Hub | BB-Browser sites, clipboard, screen |
+| **API Clip** | Wraps an external API as a Clip | GitHub CLI, 12306, Amap |
+
+## BB-Browser
+
+BB-Browser turns any website into an Agent-callable Clip by running in the user's real Chrome — reusing login sessions, cookies, SSO, and intranet access.
+
+```bash
+pinix invoke github trending
+# → structured JSON from GitHub, using your logged-in session
+
+pinix invoke twitter search --query "AI agent"
+# → Twitter search results via your account
+```
+
+Live view at `http://localhost:6111` shows what Chrome is doing in real time.
+
+## Connect to pinix.ai
+
+```bash
+pinix login
+```
+
+This connects your local Pinix to pinix.ai Cloud Hub. Your Clips become accessible from any device. pinix.ai also provides:
+
+- **Cloud Hub** — cross-network Clip routing
+- **Cloud Registry** — discover and install Clips
+- **Model Proxy** — use AI models without managing API keys
+- **Console** — manage Clips from the web
+
+## Build from Source
+
+```bash
+# Requires Go 1.22+ and Bun
+go build -o pinixd ./cmd/pinixd
+go build -o pinix ./cmd/pinix
+
+pinixd
+```
 
 ## Docs
 
@@ -60,6 +113,4 @@ CLI / MCP / Portal
 - [Clip Development](docs/clip-development.md)
 - [Edge Clip Development](docs/edge-clip-development.md)
 - [Protocol](docs/protocol.md)
-- [MCP](docs/mcp.md)
 - [Deployment](docs/deployment.md)
-- [Decisions](docs/decisions.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,57 +1,110 @@
 # Pinix
 
-Pinix 是一个 Clip runtime 和路由 Hub：本地运行 Bun/TS Clip，通过 Go Hub 做路由，并通过 Connect-RPC 接入 Edge Clip。
+**Agent Harness** — 一套开放能力层，让 Agent 发现、调用、组合和约束工具。
 
-[![Release](https://img.shields.io/github/v/release/epiral/pinix?color=blue)](https://github.com/epiral/pinix/releases/tag/v2.0.0)
-
-[English](README.md) | [中文](README.zh-CN.md)
-
-## 架构总览
+Pinix 把设备、应用、网页、服务和工作流封装成 **Clip**。每个 Clip 是独立的能力单元，可以被任何 Agent、CLI 调用。部分 Clip 还自带 Web UI，让人直接使用。
 
 ```text
-CLI / MCP / Portal
-        |
-        | Connect-RPC
-        v
-+---------------------------+
-| Hub                       |
-| 按 clip name 路由         |
-+-------------+-------------+
-              |
-      +-------+-------+
-      |               |
-      |               | ProviderStream
-      |               v
-      |         Edge Clips / Providers
-      |         (bb-browserd, devices)
-      |
-      v
- pinixd 本地 runtime
-      |
-      | NDJSON IPC v2
-      v
-   Bun/TS Clips
+人 / Agent / CLI
+  -> Hub
+  -> Clips
+  -> 设备 / 应用 / 网页 / SaaS / 工作流
 ```
 
 ## 快速开始
 
-1. 运行本地 Clip 时需要先安装 `bun`，然后从 [v2.0.0 release](https://github.com/epiral/pinix/releases/tag/v2.0.0) 下载 `pinixd` 和 `pinix`，或从源码编译。
-2. 以全包模式启动 Pinix：`./pinixd --port 9000`
-3. 安装第一个 Clip：`./pinix --server http://127.0.0.1:9000 add clip-todo`
-4. 调用命令：`./pinix --server http://127.0.0.1:9000 todo add -- --title "写文档"`
-5. 打开 `http://127.0.0.1:9000`，再用 `./pinix mcp --all --server http://127.0.0.1:9000` 暴露 MCP
-
-## pinixd 三种模式
-
 ```bash
-./pinixd --port 9000
-./pinixd --port 9000 --hub-only
-./pinixd --port 9001 --hub http://hub:9000
+# 1. 启动 Pinix
+pinixd
+
+# 2. 连接 pinix.ai
+pinix login
+
+# 3. 安装一个 Clip
+pinix hub add @pinix/todo
+
+# 4. 使用
+pinix invoke todo add --title "Hello Pinix"
+pinix invoke todo list
+
+# 5. 打开 Console
+open http://localhost:9000
 ```
 
-- 默认模式：Hub + Runtime + Portal。
-- `--hub-only`：纯 Hub + Portal，不管理本地 Clip 进程。
-- `--hub`：纯 Runtime。作为 Provider 连接外部 Hub，并把自己管理的 Clips 注册上去。
+`pinix login` 后，你的本地 Clips 通过 pinix.ai Cloud Hub 在任何设备上都可以访问。
+
+## 启动 Pinix 后发生了什么
+
+```text
+pinixd
+  ├── Hub        — 路由 invoke 调用到正确的 Clip
+  ├── Runtime    — 管理本地 Bun/TS Clip 进程
+  ├── Registry   — 从 pinix.ai Registry 安装 Clips
+  └── Console    — localhost:9000 的 Web 管理界面
+```
+
+如果安装了 BB-Browser，它会自动启动一个 headless Chrome，并把浏览器能力注册为 Edge Clips：
+
+```text
+pinix hub list
+
+  github     RUNNING   trending, repo, search
+  twitter    RUNNING   search, timeline
+  reddit     RUNNING   search, hot
+  todo       RUNNING   add, delete, list
+```
+
+## Clips
+
+Clip 是 Pinix 的核心抽象。它提供两个关键价值：
+
+1. **降低模型要求。** 复杂操作被封装成确定性命令，Agent 只需要调用，不需要理解实现细节。
+2. **圈定能力边界。** Agent 只能通过 Clip 获取能力，权限、审计和测试都是内置的。
+
+三类 Clip：
+
+| 类型 | 工作方式 | 例子 |
+|---|---|---|
+| **SDK Clip** | Bun/TS 应用，由 Runtime 管理，通过 `pinix hub add` 安装 | todo, review, memex |
+| **Edge Clip** | 原生进程，自实现 Provider 协议，自动注册到 Hub | BB-Browser sites, clipboard, screen |
+| **API Clip** | 封装外部 API 为 Clip | GitHub CLI, 12306, 高德地图 |
+
+## BB-Browser
+
+BB-Browser 把任何网站变成 Agent 可调用的 Clip。它运行在用户真实的 Chrome 里，复用已有的登录态、Cookie、SSO 和内网环境。
+
+```bash
+pinix invoke github trending
+# → GitHub trending 的结构化 JSON，使用你已登录的账号
+
+pinix invoke twitter search --query "AI agent"
+# → Twitter 搜索结果，通过你的账号
+```
+
+实时画面在 `http://localhost:6111`，可以看到 Chrome 正在做什么。
+
+## 连接 pinix.ai
+
+```bash
+pinix login
+```
+
+这会把你的本地 Pinix 连接到 pinix.ai Cloud Hub。你的 Clips 在任何设备上都可以访问。pinix.ai 还提供：
+
+- **Cloud Hub** — 跨网络 Clip 路由
+- **Cloud Registry** — 发现和安装 Clips
+- **模型代理** — 使用 AI 模型不需要自己管 API key
+- **Console** — 从网页管理 Clips
+
+## 从源码编译
+
+```bash
+# 需要 Go 1.22+ 和 Bun
+go build -o pinixd ./cmd/pinixd
+go build -o pinix ./cmd/pinix
+
+pinixd
+```
 
 ## 文档
 
@@ -60,6 +113,4 @@ CLI / MCP / Portal
 - [Clip 开发](docs/clip-development.md)
 - [Edge Clip 开发](docs/edge-clip-development.md)
 - [协议](docs/protocol.md)
-- [MCP](docs/mcp.md)
 - [部署](docs/deployment.md)
-- [决策索引](docs/decisions.md)


### PR DESCRIPTION
## 改动

重写 README.md 和 README.zh-CN.md，从 "Clip runtime + routing Hub" 改为 Agent Harness 定位。

### 新结构

1. **一句话定位**：Agent Harness — 开放能力层
2. **Quick Start**：pinixd → pinix login → add Clip → invoke → Console
3. **启动后发生了什么**：Hub + Runtime + Registry + Console + BB-Browser auto-register
4. **Clips**：核心抽象，三类 Clip
5. **BB-Browser**：网站变 Clip
6. **连接 pinix.ai**：Cloud Hub + Registry + Model Proxy
7. **从源码编译**
8. **文档链接**

### 删除

- 旧的 pinixd 三种模式说明（开发者文档里有）
- MCP 相关内容
- release badge（暂时移除，后续更新版本号后加回）

Closes #123 (partial)