### PR TITLE
feat(cli): add pinix start/stop/status — single binary Ollama mode

### DIFF
--- a/cmd/pinix/daemon.go
+++ b/cmd/pinix/daemon.go
@@ -1,0 +1,267 @@
+// Role:    Hidden "daemon" subcommand — runs pinixd logic inside the pinix binary
+// Depends: context, fmt, log/slog, net, os, os/signal, path/filepath, strings, sync, syscall, time, internal/config, internal/daemon, internal/logging, internal/pidfile, cobra
+// Exports: newDaemonCommand
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	configpkg "github.com/epiral/pinix/internal/config"
+	"github.com/epiral/pinix/internal/daemon"
+	"github.com/epiral/pinix/internal/logging"
+	"github.com/epiral/pinix/internal/pidfile"
+	"github.com/spf13/cobra"
+)
+
+func newDaemonCommand() *cobra.Command {
+	var (
+		superToken string
+		configPath string
+		bunPath    string
+		hubURL     string
+		hubToken   string
+		port       int
+		pidPath    string
+		hubOnly    bool
+		logLevel   string
+	)
+
+	cmd := &cobra.Command{
+		Use:    "daemon",
+		Short:  "Run the Pinix daemon (internal use)",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDaemon(daemonOptions{
+				superToken: superToken,
+				configPath: configPath,
+				bunPath:    bunPath,
+				hubURL:     hubURL,
+				hubToken:   hubToken,
+				port:       port,
+				pidPath:    pidPath,
+				hubOnly:    hubOnly,
+				logLevel:   logLevel,
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&superToken, "super-token", "", "super token required for protected add/remove operations")
+	cmd.Flags().StringVar(&configPath, "config", "", "config path (default: ~/.pinix/config.json)")
+	cmd.Flags().StringVar(&bunPath, "bun", "", "path to bun binary (default: auto-detect)")
+	cmd.Flags().StringVar(&hubURL, "hub", "", "connect to an external hub as a runtime provider")
+	cmd.Flags().StringVar(&hubToken, "hub-token", "", "JWT token for authenticating with the external hub (env: PINIX_HUB_TOKEN)")
+	cmd.Flags().BoolVar(&hubOnly, "hub-only", false, "run Hub + Portal only, without a local runtime")
+	cmd.Flags().IntVar(&port, "port", 9000, "http port for the embedded portal UI")
+	cmd.Flags().StringVar(&pidPath, "pid", "", "custom path to PID file (default: ~/.pinix/pinixd.pid)")
+	cmd.Flags().StringVar(&logLevel, "log-level", "info", "log level: debug, info, warn, error")
+
+	return cmd
+}
+
+type daemonOptions struct {
+	superToken string
+	configPath string
+	bunPath    string
+	hubURL     string
+	hubToken   string
+	port       int
+	pidPath    string
+	hubOnly    bool
+	logLevel   string
+}
+
+func runDaemon(opts daemonOptions) error {
+	// Setup structured JSON logging to stderr + file
+	home, err := os.UserHomeDir()
+	if err != nil {
+		slog.Error("failed to get home directory for logging", "error", err)
+	} else {
+		logDir := filepath.Join(home, ".pinix", "logs")
+		cleanup, err := logging.Setup(logDir, logging.ParseLevel(opts.logLevel))
+		if err != nil {
+			slog.Error("failed to setup file logging", "error", err)
+		} else {
+			defer cleanup()
+		}
+	}
+
+	clientConfig := loadDaemonClientConfig()
+
+	// Resolve hub-token: flag > env > config file
+	hubToken := opts.hubToken
+	if hubToken == "" {
+		hubToken = strings.TrimSpace(os.Getenv("PINIX_HUB_TOKEN"))
+	}
+	autoConnect := false
+	if hubToken == "" && strings.TrimSpace(clientConfig.HubToken) != "" {
+		hubToken = strings.TrimSpace(clientConfig.HubToken)
+		autoConnect = true
+	}
+
+	// Resolve hub: flag > env > config file
+	hubURL := strings.TrimSpace(opts.hubURL)
+	if hubURL == "" {
+		if v := strings.TrimSpace(os.Getenv("PINIX_HUB")); v != "" {
+			hubURL = v
+		} else if v := strings.TrimSpace(clientConfig.Hub); v != "" {
+			hubURL = v
+		} else if hubToken != "" {
+			hubURL = "https://hub.pinixai.com"
+		}
+	}
+
+	if autoConnect && hubURL != "" {
+		slog.Info("hub: auto-connecting from config", "hub", hubURL)
+	}
+	if opts.hubOnly && hubURL != "" {
+		return fmt.Errorf("--hub and --hub-only cannot be used together")
+	}
+
+	registry, err := daemon.NewRegistry(opts.configPath)
+	if err != nil {
+		return err
+	}
+	if err := daemon.EnsureLogsDir(registry.RootDir()); err != nil {
+		return fmt.Errorf("create logs directory: %w", err)
+	}
+	if opts.superToken != "" {
+		if err := registry.SetSuperToken(opts.superToken); err != nil {
+			return err
+		}
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	// PID file: prevent duplicate pinixd, enable CLI auto-discovery
+	if err := pidfile.CheckExistingPIDFile(opts.port, opts.pidPath); err != nil {
+		return err
+	}
+	pidCleanup, err := pidfile.WritePIDFile(opts.port, pidfile.WritePIDFileOptions{
+		Hub:        hubURL,
+		CustomPath: opts.pidPath,
+	})
+	if err != nil {
+		return fmt.Errorf("write pid file: %w", err)
+	}
+	defer pidCleanup()
+
+	// Mode 1: Hub only (no local runtime)
+	if opts.hubOnly {
+		d, err := daemon.NewHubDaemon(registry)
+		if err != nil {
+			return err
+		}
+		return d.ServeHTTP(ctx, fmt.Sprintf(":%d", opts.port))
+	}
+
+	// Mode 2: Runtime connects to external Hub
+	if hubURL != "" {
+		processManager, err := daemon.NewProcessManager(registry, opts.bunPath, hubURL)
+		if err != nil {
+			return err
+		}
+		d, err := daemon.NewDaemon(registry, processManager)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = d.Close() }()
+		return d.ConnectHub(ctx, hubURL, opts.port, hubToken)
+	}
+
+	// Mode 3: Hub + Runtime in same process
+	addr := fmt.Sprintf(":%d", opts.port)
+	localHubURL := fmt.Sprintf("http://127.0.0.1:%d", opts.port)
+
+	hubDaemon, err := daemon.NewHubDaemon(registry)
+	if err != nil {
+		return err
+	}
+
+	var wg sync.WaitGroup
+	hubErr := make(chan error, 1)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := hubDaemon.ServeHTTP(ctx, addr); err != nil {
+			hubErr <- err
+		}
+	}()
+
+	if err := waitForDaemonHub(ctx, localHubURL, 5*time.Second); err != nil {
+		return fmt.Errorf("hub failed to start: %w", err)
+	}
+
+	processManager, err := daemon.NewProcessManager(registry, opts.bunPath, localHubURL)
+	if err != nil {
+		return err
+	}
+	runtimeDaemon, err := daemon.NewDaemon(registry, processManager)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = runtimeDaemon.Close() }()
+
+	runtimeErr := make(chan error, 1)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := runtimeDaemon.ConnectHub(ctx, localHubURL, opts.port, ""); err != nil {
+			runtimeErr <- err
+		}
+	}()
+
+	select {
+	case err := <-hubErr:
+		return fmt.Errorf("hub: %w", err)
+	case err := <-runtimeErr:
+		return fmt.Errorf("runtime: %w", err)
+	case <-ctx.Done():
+	}
+
+	_ = runtimeDaemon.Close()
+	_ = hubDaemon.Close()
+	wg.Wait()
+	return nil
+}
+
+func waitForDaemonHub(ctx context.Context, hubURL string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	host := strings.TrimPrefix(hubURL, "http://")
+	host = strings.TrimPrefix(host, "https://")
+
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		conn, err := net.DialTimeout("tcp", host, 200*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("timeout waiting for %s", hubURL)
+}
+
+func loadDaemonClientConfig() *configpkg.ClientConfig {
+	cfg, err := configpkg.ReadClientConfig()
+	if err != nil || cfg == nil {
+		return &configpkg.ClientConfig{}
+	}
+	return cfg
+}

--- a/cmd/pinix/main.go
+++ b/cmd/pinix/main.go
@@ -42,6 +42,10 @@ func newRootCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 
+	rootCmd.AddCommand(newDaemonCommand())
+	rootCmd.AddCommand(newStartCommand())
+	rootCmd.AddCommand(newStopCommand())
+	rootCmd.AddCommand(newStatusCommand())
 	rootCmd.AddCommand(newAuthLoginCommand())
 	rootCmd.AddCommand(newAuthLogoutCommand())
 	rootCmd.AddCommand(newAuthWhoAmICommand())

--- a/cmd/pinix/process_unix.go
+++ b/cmd/pinix/process_unix.go
@@ -1,0 +1,41 @@
+// Role:    Unix-specific process helpers for start/stop commands
+// Depends: os, syscall
+// Exports: daemonSysProcAttr, checkProcessAlive, signalProcess
+
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// daemonSysProcAttr returns SysProcAttr to detach the child from the parent session.
+func daemonSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		Setsid: true,
+	}
+}
+
+// checkProcessAlive checks if a process with the given PID exists.
+func checkProcessAlive(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("process %d not found: %w", pid, err)
+	}
+	if err := proc.Signal(syscall.Signal(0)); err != nil {
+		return fmt.Errorf("process %d is dead: %w", pid, err)
+	}
+	return nil
+}
+
+// signalProcess sends a signal to a process.
+func signalProcess(pid int, sig os.Signal) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return proc.Signal(sig)
+}

--- a/cmd/pinix/start.go
+++ b/cmd/pinix/start.go
@@ -1,0 +1,148 @@
+// Role:    "start" subcommand — start the Pinix daemon in background or foreground
+// Depends: fmt, os, os/exec, path/filepath, time, internal/pidfile, cobra
+// Exports: newStartCommand
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/epiral/pinix/internal/pidfile"
+	"github.com/spf13/cobra"
+)
+
+func newStartCommand() *cobra.Command {
+	var (
+		foreground bool
+		superToken string
+		configPath string
+		bunPath    string
+		hubURL     string
+		hubToken   string
+		port       int
+		pidPath    string
+		hubOnly    bool
+		logLevel   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start the Pinix daemon",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Check if already running
+			pf, err := pidfile.ReadPIDFile(pidPath)
+			if err != nil {
+				return err
+			}
+			if pf != nil {
+				fmt.Printf("Pinix is already running (PID %d, port %d)\n", pf.PID, pf.Port)
+				return nil
+			}
+
+			// Foreground mode: run daemon directly in this process
+			if foreground {
+				return runDaemon(daemonOptions{
+					superToken: superToken,
+					configPath: configPath,
+					bunPath:    bunPath,
+					hubURL:     hubURL,
+					hubToken:   hubToken,
+					port:       port,
+					pidPath:    pidPath,
+					hubOnly:    hubOnly,
+					logLevel:   logLevel,
+				})
+			}
+
+			// Background mode: spawn "pinix daemon" as a child process
+			daemonArgs := []string{"daemon"}
+			daemonArgs = append(daemonArgs, "--port", fmt.Sprintf("%d", port))
+			daemonArgs = append(daemonArgs, "--log-level", logLevel)
+			if superToken != "" {
+				daemonArgs = append(daemonArgs, "--super-token", superToken)
+			}
+			if configPath != "" {
+				daemonArgs = append(daemonArgs, "--config", configPath)
+			}
+			if bunPath != "" {
+				daemonArgs = append(daemonArgs, "--bun", bunPath)
+			}
+			if hubURL != "" {
+				daemonArgs = append(daemonArgs, "--hub", hubURL)
+			}
+			if hubToken != "" {
+				daemonArgs = append(daemonArgs, "--hub-token", hubToken)
+			}
+			if pidPath != "" {
+				daemonArgs = append(daemonArgs, "--pid", pidPath)
+			}
+			if hubOnly {
+				daemonArgs = append(daemonArgs, "--hub-only")
+			}
+
+			// Resolve log file path
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("get home directory: %w", err)
+			}
+			pinixDir := filepath.Join(home, ".pinix")
+			if err := os.MkdirAll(pinixDir, 0o755); err != nil {
+				return fmt.Errorf("create .pinix directory: %w", err)
+			}
+			logFile, err := os.OpenFile(
+				filepath.Join(pinixDir, "pinixd.log"),
+				os.O_CREATE|os.O_WRONLY|os.O_APPEND,
+				0o644,
+			)
+			if err != nil {
+				return fmt.Errorf("open log file: %w", err)
+			}
+
+			executable, err := os.Executable()
+			if err != nil {
+				return fmt.Errorf("resolve executable path: %w", err)
+			}
+
+			child := exec.Command(executable, daemonArgs...)
+			child.Stdout = logFile
+			child.Stderr = logFile
+			// Detach from parent process group
+			child.SysProcAttr = daemonSysProcAttr()
+
+			if err := child.Start(); err != nil {
+				_ = logFile.Close()
+				return fmt.Errorf("start daemon: %w", err)
+			}
+			_ = logFile.Close()
+
+			// Wait briefly and verify the process is still alive
+			time.Sleep(2 * time.Second)
+			if child.Process != nil {
+				if err := checkProcessAlive(child.Process.Pid); err != nil {
+					return fmt.Errorf("daemon exited shortly after start; check ~/.pinix/pinixd.log for details")
+				}
+			}
+
+			fmt.Printf("Pinix started on :%d (PID %d)\n", port, child.Process.Pid)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&foreground, "foreground", false, "run in foreground instead of daemonizing")
+	cmd.Flags().StringVar(&superToken, "super-token", "", "super token required for protected add/remove operations")
+	cmd.Flags().StringVar(&configPath, "config", "", "config path (default: ~/.pinix/config.json)")
+	cmd.Flags().StringVar(&bunPath, "bun", "", "path to bun binary (default: auto-detect)")
+	cmd.Flags().StringVar(&hubURL, "hub", "", "connect to an external hub as a runtime provider")
+	cmd.Flags().StringVar(&hubToken, "hub-token", "", "JWT token for authenticating with the external hub (env: PINIX_HUB_TOKEN)")
+	cmd.Flags().BoolVar(&hubOnly, "hub-only", false, "run Hub + Portal only, without a local runtime")
+	cmd.Flags().IntVar(&port, "port", 9000, "http port for the embedded portal UI")
+	cmd.Flags().StringVar(&pidPath, "pid", "", "custom path to PID file (default: ~/.pinix/pinixd.pid)")
+	cmd.Flags().StringVar(&logLevel, "log-level", "info", "log level: debug, info, warn, error")
+
+	return cmd
+}

--- a/cmd/pinix/status.go
+++ b/cmd/pinix/status.go
@@ -1,0 +1,51 @@
+// Role:    "status" subcommand — check whether the Pinix daemon is running
+// Depends: fmt, net/http, time, internal/pidfile, cobra
+// Exports: newStatusCommand
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/epiral/pinix/internal/pidfile"
+	"github.com/spf13/cobra"
+)
+
+func newStatusCommand() *cobra.Command {
+	var pidPath string
+
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Check if the Pinix daemon is running",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pf, err := pidfile.ReadPIDFile(pidPath)
+			if err != nil {
+				return err
+			}
+			if pf == nil {
+				fmt.Println("Pinix is not running")
+				return nil
+			}
+
+			// Process exists, try HTTP health check
+			url := fmt.Sprintf("http://127.0.0.1:%d/healthz", pf.Port)
+			httpClient := &http.Client{Timeout: 2 * time.Second}
+			resp, err := httpClient.Get(url)
+			if err != nil {
+				fmt.Printf("Pinix is running (PID %d, port %d) but not responding to HTTP\n", pf.PID, pf.Port)
+				return nil
+			}
+			_ = resp.Body.Close()
+
+			fmt.Printf("Pinix is running (PID %d, port %d)\n", pf.PID, pf.Port)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&pidPath, "pid", "", "custom path to PID file (default: ~/.pinix/pinixd.pid)")
+
+	return cmd
+}

--- a/cmd/pinix/stop.go
+++ b/cmd/pinix/stop.go
@@ -1,0 +1,70 @@
+// Role:    "stop" subcommand — stop the running Pinix daemon
+// Depends: fmt, os, syscall, time, internal/pidfile, cobra
+// Exports: newStopCommand
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/epiral/pinix/internal/pidfile"
+	"github.com/spf13/cobra"
+)
+
+func newStopCommand() *cobra.Command {
+	var pidPath string
+
+	cmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the running Pinix daemon",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pf, err := pidfile.ReadPIDFile(pidPath)
+			if err != nil {
+				return err
+			}
+			if pf == nil {
+				fmt.Println("Pinix is not running")
+				return nil
+			}
+
+			pid := pf.PID
+
+			// Send SIGTERM
+			if err := signalProcess(pid, syscall.SIGTERM); err != nil {
+				// Process already gone
+				fmt.Println("Pinix stopped (process already exited)")
+				return nil
+			}
+
+			// Wait for process to exit (up to 10 seconds)
+			deadline := time.Now().Add(10 * time.Second)
+			for time.Now().Before(deadline) {
+				if err := checkProcessAlive(pid); err != nil {
+					fmt.Println("Pinix stopped")
+					return nil
+				}
+				time.Sleep(200 * time.Millisecond)
+			}
+
+			// Process didn't exit — send SIGKILL
+			_ = signalProcess(pid, os.Kill)
+			time.Sleep(500 * time.Millisecond)
+
+			// Clean up PID file
+			if err := checkProcessAlive(pid); err != nil {
+				fmt.Println("Pinix stopped (killed)")
+				return nil
+			}
+
+			return fmt.Errorf("failed to stop Pinix (PID %d)", pid)
+		},
+	}
+
+	cmd.Flags().StringVar(&pidPath, "pid", "", "custom path to PID file (default: ~/.pinix/pinixd.pid)")
+
+	return cmd
+}


### PR DESCRIPTION
Closes #129

## 改动

合并 pinixd 到 pinix binary。用户只需要一个 `pinix`。

### 新命令

```bash
pinix start              # 后台启动 daemon
pinix stop               # 停止 daemon
pinix status             # 查看状态
pinix start --foreground # 前台模式
```

### 用户流程

```bash
pinix start
pinix login
pinix hub add @pinix/todo
pinix invoke todo list
pinix stop
```

### 实现

- `cmd/pinix/daemon.go`：隐藏子命令，复制了 `cmd/pinixd/main.go` 的核心逻辑
- `cmd/pinix/start.go`：fork `pinix daemon` 后台启动，写 PID file，日志到 `~/.pinix/pinixd.log`
- `cmd/pinix/stop.go`：读 PID，发 SIGTERM，等待退出
- `cmd/pinix/status.go`：检查 PID 和 HTTP 健康
- `cmd/pinix/process_unix.go`：Unix 进程存在性检查
- `cmd/pinix/main.go`：注册新命令

### 不影响

- `cmd/pinixd/main.go` 保留，仍可独立编译为 `pinixd`
- `internal/daemon/` 核心逻辑无改动
- Proto 无改动

### 测试

- build/vet/test 通过
- `pinix start` → 后台启动
- `pinix status` → running
- `pinix hub list` → 正常
- `pinix stop` → 停止
- `pinix status` → not running
- `pinix start` 两次 → 第二次提示已运行