### PR TITLE
feat: add Windows support for pinixd and pinix CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,18 @@ jobs:
       - run: go build ./cmd/pinix
       - run: go vet ./...
       - run: go test ./...
+
+  check-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+      - uses: bufbuild/buf-setup-action@v1
+      - name: Generate proto
+        run: buf generate
+      - run: go build ./cmd/pinixd
+      - run: go build ./cmd/pinix
+      - run: go vet ./...
+      - run: go test ./...

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ build-all:
 	GOOS=linux GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o dist/pinix-linux-arm64 ./cmd/pinix
 	GOOS=darwin GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o dist/pinixd-darwin-arm64 ./cmd/pinixd
 	GOOS=darwin GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o dist/pinix-darwin-arm64 ./cmd/pinix
+	GOOS=windows GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o dist/pinixd-windows-amd64.exe ./cmd/pinixd
+	GOOS=windows GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o dist/pinix-windows-amd64.exe ./cmd/pinix
 
 test:
 	go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,18 @@ upload-cos: build-all
 	coscmd upload -H '{"x-cos-acl":"public-read"}' dist/pinix-linux-arm64 releases/latest/pinix-linux-arm64
 	coscmd upload -H '{"x-cos-acl":"public-read"}' dist/pinixd-darwin-arm64 releases/latest/pinixd-darwin-arm64
 	coscmd upload -H '{"x-cos-acl":"public-read"}' dist/pinix-darwin-arm64 releases/latest/pinix-darwin-arm64
+	coscmd upload -H '{"x-cos-acl":"public-read"}' dist/pinixd-windows-amd64.exe releases/latest/pinixd-windows-amd64.exe
+	coscmd upload -H '{"x-cos-acl":"public-read"}' dist/pinix-windows-amd64.exe releases/latest/pinix-windows-amd64.exe
 	coscmd upload -H '{"x-cos-acl":"public-read"}' install.sh install.sh
+	coscmd upload -H '{"x-cos-acl":"public-read"}' install.ps1 install.ps1
 	@echo "Upload complete."
 	@echo ""
 	@echo "Verify:"
 	@echo "  curl -sI https://dl.pinixai.com/install.sh"
+	@echo "  curl -sI https://dl.pinixai.com/install.ps1"
 	@echo "  curl -sI https://dl.pinixai.com/releases/latest/pinix-darwin-arm64"
 	@echo "  curl -sI https://dl.pinixai.com/releases/latest/pinix-linux-amd64"
+	@echo "  curl -sI https://dl.pinixai.com/releases/latest/pinix-windows-amd64.exe"
 
 clean:
 	rm -f pinixd pinix

--- a/cmd/pinix/daemon.go
+++ b/cmd/pinix/daemon.go
@@ -150,6 +150,11 @@ func runDaemon(opts daemonOptions) error {
 		}
 	}
 
+	// On Windows, prevent CTRL_CLOSE_EVENT from killing the daemon when
+	// the parent console/SSH session closes. Must be called before
+	// signal.NotifyContext so Go's handler takes precedence for Interrupt.
+	setupDaemonSignalHandling()
+
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 

--- a/cmd/pinix/daemon.go
+++ b/cmd/pinix/daemon.go
@@ -1,5 +1,5 @@
 // Role:    Hidden "daemon" subcommand — runs pinixd logic inside the pinix binary
-// Depends: context, fmt, log/slog, net, os, os/signal, path/filepath, strings, sync, syscall, time, internal/config, internal/daemon, internal/logging, internal/pidfile, cobra
+// Depends: context, fmt, log/slog, net, os, os/exec, os/signal, path/filepath, strings, sync, time, internal/config, internal/daemon, internal/logging, internal/pidfile, cobra
 // Exports: newDaemonCommand
 
 package main
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	configpkg "github.com/epiral/pinix/internal/config"
@@ -151,7 +150,7 @@ func runDaemon(opts daemonOptions) error {
 		}
 	}
 
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
 	// PID file: prevent duplicate pinixd, enable CLI auto-discovery
@@ -283,9 +282,7 @@ func runDaemon(opts daemonOptions) error {
 
 	if cmd := browserCmd.Load(); cmd != nil && cmd.Process != nil {
 		slog.Info("stopping bb-browser daemon")
-		// Kill the entire process group (bb-browser-daemon + its managed Chrome).
-		// The monitor goroutine handles cmd.Wait().
-		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+		killBrowserProcessGroup(cmd)
 	}
 	_ = runtimeDaemon.Close()
 	_ = hubDaemon.Close()
@@ -297,7 +294,7 @@ func runDaemon(opts daemonOptions) error {
 // It connects to the best available hub (Cloud Hub if available, otherwise local).
 // The child runs in its own process group (Setpgid) so that signals sent to
 // pinixd do not cascade into bb-browser prematurely. On shutdown, the caller
-// sends SIGTERM to the process group via syscall.Kill(-pid, SIGTERM).
+// sends a termination signal to the process group via killBrowserProcessGroup().
 func startBrowserDaemon(localHubURL, hubToken, cloudHubURL string) *exec.Cmd {
 	bin, err := exec.LookPath("bb-browser-daemon")
 	if err != nil {
@@ -333,7 +330,7 @@ func startBrowserDaemon(localHubURL, hubToken, cloudHubURL string) *exec.Cmd {
 	cmd := exec.Command(bin, args...)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.SysProcAttr = browserDaemonSysProcAttr()
 
 	if err := cmd.Start(); err != nil {
 		slog.Error("failed to start bb-browser daemon", "error", err)

--- a/cmd/pinix/daemon_process_unix.go
+++ b/cmd/pinix/daemon_process_unix.go
@@ -1,0 +1,24 @@
+// Role:    Unix-specific bb-browser process management helpers
+// Depends: os/exec, syscall
+// Exports: browserDaemonSysProcAttr, killBrowserProcessGroup
+
+//go:build !windows
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// browserDaemonSysProcAttr returns SysProcAttr to run bb-browser in its own process group.
+func browserDaemonSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killBrowserProcessGroup kills the entire bb-browser process group.
+func killBrowserProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process != nil {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+	}
+}

--- a/cmd/pinix/daemon_process_windows.go
+++ b/cmd/pinix/daemon_process_windows.go
@@ -1,0 +1,31 @@
+// Role:    Windows-specific bb-browser process management helpers
+// Depends: os/exec, syscall
+// Exports: browserDaemonSysProcAttr, killBrowserProcessGroup
+
+//go:build windows
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+const (
+	_CREATE_NEW_PROCESS_GROUP = 0x00000200
+	_CREATE_NO_WINDOW         = 0x08000000
+)
+
+// browserDaemonSysProcAttr returns SysProcAttr to run bb-browser in its own process group.
+func browserDaemonSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		CreationFlags: _CREATE_NEW_PROCESS_GROUP | _CREATE_NO_WINDOW,
+	}
+}
+
+// killBrowserProcessGroup terminates the bb-browser process tree on Windows.
+func killBrowserProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process != nil {
+		cmd.Process.Kill()
+	}
+}

--- a/cmd/pinix/daemon_signal_unix.go
+++ b/cmd/pinix/daemon_signal_unix.go
@@ -1,0 +1,11 @@
+// Role:    Unix-specific daemon signal setup (no-op)
+// Depends: (none)
+// Exports: setupDaemonSignalHandling
+
+//go:build !windows
+
+package main
+
+// setupDaemonSignalHandling is a no-op on Unix; signal handling is fully
+// managed by signal.NotifyContext in the main daemon code.
+func setupDaemonSignalHandling() {}

--- a/cmd/pinix/daemon_signal_windows.go
+++ b/cmd/pinix/daemon_signal_windows.go
@@ -1,0 +1,28 @@
+// Role:    Windows-specific daemon signal setup — ignore console close events
+// Depends: syscall
+// Exports: setupDaemonSignalHandling
+
+//go:build windows
+
+package main
+
+import "syscall"
+
+var procSetConsoleCtrlHandler = syscall.NewLazyDLL("kernel32.dll").NewProc("SetConsoleCtrlHandler")
+
+// setupDaemonSignalHandling calls SetConsoleCtrlHandler(NULL, TRUE) to prevent
+// the daemon from being killed by CTRL_CLOSE_EVENT when the parent SSH session
+// or console window closes. The daemon is instead stopped via "pinix stop"
+// which sends CTRL_BREAK_EVENT or TerminateProcess.
+func setupDaemonSignalHandling() {
+	// SetConsoleCtrlHandler(NULL, TRUE) causes the process to ignore
+	// CTRL_C_EVENT and CTRL_BREAK_EVENT from the console.
+	// However, Go's signal.NotifyContext will still intercept os.Interrupt
+	// via its own SetConsoleCtrlHandler, so "pinix stop" sending
+	// CTRL_BREAK_EVENT will still trigger graceful shutdown.
+	//
+	// The critical fix: without this call, CTRL_CLOSE_EVENT (sent when the
+	// console/SSH session closes) kills the process before Go's signal
+	// handler can even run.
+	procSetConsoleCtrlHandler.Call(0, 1)
+}

--- a/cmd/pinix/process_windows.go
+++ b/cmd/pinix/process_windows.go
@@ -1,0 +1,78 @@
+// Role:    Windows-specific process helpers for start/stop commands
+// Depends: fmt, os, syscall, unsafe
+// Exports: daemonSysProcAttr, checkProcessAlive, signalProcess
+
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	modkernel32              = syscall.NewLazyDLL("kernel32.dll")
+	procOpenProcess          = modkernel32.NewProc("OpenProcess")
+	procGenerateConsoleCtrlEvent = modkernel32.NewProc("GenerateConsoleCtrlEvent")
+)
+
+const (
+	processQueryLimitedInformation = 0x1000
+	createNewProcessGroup          = 0x00000200
+	createNoWindow                 = 0x08000000
+)
+
+// daemonSysProcAttr returns SysProcAttr to run the daemon as a detached process
+// in its own process group (CREATE_NEW_PROCESS_GROUP).
+func daemonSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		CreationFlags: createNewProcessGroup | createNoWindow,
+	}
+}
+
+// checkProcessAlive checks if a process with the given PID exists.
+// On Windows, we use OpenProcess with PROCESS_QUERY_LIMITED_INFORMATION.
+func checkProcessAlive(pid int) error {
+	h, _, err := procOpenProcess.Call(
+		uintptr(processQueryLimitedInformation),
+		0,
+		uintptr(pid),
+	)
+	if h == 0 {
+		return fmt.Errorf("process %d is dead: %v", pid, err)
+	}
+	syscall.CloseHandle(syscall.Handle(h))
+	return nil
+}
+
+// signalProcess sends a signal to a process.
+// On Windows, os.Kill is the only supported signal via Process.Signal().
+// For SIGTERM-like behavior, we try GenerateConsoleCtrlEvent first (CTRL_BREAK_EVENT),
+// and fall back to TerminateProcess via os.Process.Kill().
+func signalProcess(pid int, sig os.Signal) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+
+	if sig == os.Kill {
+		return proc.Kill()
+	}
+
+	// Try CTRL_BREAK_EVENT for graceful shutdown (works for processes in their own group).
+	ret, _, callErr := procGenerateConsoleCtrlEvent.Call(
+		uintptr(syscall.CTRL_BREAK_EVENT),
+		uintptr(pid),
+	)
+	_ = unsafe.Pointer(nil) // keep unsafe import used
+	if ret != 0 {
+		return nil
+	}
+
+	// GenerateConsoleCtrlEvent failed — fall back to Kill.
+	_ = callErr
+	return proc.Kill()
+}

--- a/cmd/pinix/process_windows.go
+++ b/cmd/pinix/process_windows.go
@@ -22,14 +22,23 @@ var (
 const (
 	processQueryLimitedInformation = 0x1000
 	createNewProcessGroup          = 0x00000200
-	createNoWindow                 = 0x08000000
+	detachedProcess                = 0x00000008
+	createBreakawayFromJob         = 0x01000000
 )
 
-// daemonSysProcAttr returns SysProcAttr to run the daemon as a detached process
-// in its own process group (CREATE_NEW_PROCESS_GROUP).
+// daemonSysProcAttr returns SysProcAttr to run the daemon as a fully detached
+// background process.
+//
+// - DETACHED_PROCESS: detach from the parent console so the child survives
+//   after the parent (pinix start) exits.
+// - CREATE_NEW_PROCESS_GROUP: give the daemon its own process group.
+// - CREATE_BREAKAWAY_FROM_JOB: break out of the parent's Job Object. This is
+//   critical when pinix is launched from OpenSSH Server, which uses a Job
+//   Object to manage session processes. Without this flag, sshd kills the
+//   daemon when the SSH session ends.
 func daemonSysProcAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{
-		CreationFlags: createNewProcessGroup | createNoWindow,
+		CreationFlags: createNewProcessGroup | detachedProcess | createBreakawayFromJob,
 	}
 }
 

--- a/cmd/pinix/start.go
+++ b/cmd/pinix/start.go
@@ -1,5 +1,5 @@
 // Role:    "start" subcommand — start the Pinix daemon in background or foreground
-// Depends: fmt, os, os/exec, path/filepath, time, internal/pidfile, cobra
+// Depends: fmt, os, path/filepath, internal/pidfile, cobra
 // Exports: newStartCommand
 
 package main
@@ -7,9 +7,7 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"time"
 
 	"github.com/epiral/pinix/internal/pidfile"
 	"github.com/spf13/cobra"
@@ -108,27 +106,12 @@ func newStartCommand() *cobra.Command {
 				return fmt.Errorf("resolve executable path: %w", err)
 			}
 
-			child := exec.Command(executable, daemonArgs...)
-			child.Stdout = logFile
-			child.Stderr = logFile
-			// Detach from parent process group
-			child.SysProcAttr = daemonSysProcAttr()
-
-			if err := child.Start(); err != nil {
-				_ = logFile.Close()
-				return fmt.Errorf("start daemon: %w", err)
-			}
-			_ = logFile.Close()
-
-			// Wait briefly and verify the process is still alive
-			time.Sleep(2 * time.Second)
-			if child.Process != nil {
-				if err := checkProcessAlive(child.Process.Pid); err != nil {
-					return fmt.Errorf("daemon exited shortly after start; check ~/.pinix/pinixd.log for details")
-				}
+			childPid, err := startBackgroundDaemon(executable, daemonArgs, logFile)
+			if err != nil {
+				return err
 			}
 
-			fmt.Printf("Pinix started on :%d (PID %d)\n", port, child.Process.Pid)
+			fmt.Printf("Pinix started on :%d (PID %d)\n", port, childPid)
 			fmt.Println()
 			fmt.Println("Next:")
 			fmt.Printf("  pinix login                        log in to Pinix\n")

--- a/cmd/pinix/start_daemon_unix.go
+++ b/cmd/pinix/start_daemon_unix.go
@@ -1,0 +1,36 @@
+// Role:    Unix-specific background daemon launch
+// Depends: fmt, os, os/exec, time
+// Exports: startBackgroundDaemon
+
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// startBackgroundDaemon spawns the daemon as a detached child process.
+// Returns the child PID on success.
+func startBackgroundDaemon(executable string, daemonArgs []string, logFile *os.File) (int, error) {
+	child := exec.Command(executable, daemonArgs...)
+	child.Stdout = logFile
+	child.Stderr = logFile
+	child.SysProcAttr = daemonSysProcAttr()
+
+	if err := child.Start(); err != nil {
+		return 0, fmt.Errorf("start daemon: %w", err)
+	}
+	childPid := child.Process.Pid
+	_ = logFile.Close()
+
+	// Wait briefly and verify the process is still alive
+	time.Sleep(2 * time.Second)
+	if err := checkProcessAlive(childPid); err != nil {
+		return 0, fmt.Errorf("daemon exited shortly after start; check ~/.pinix/pinixd.log for details")
+	}
+	return childPid, nil
+}

--- a/cmd/pinix/start_daemon_windows.go
+++ b/cmd/pinix/start_daemon_windows.go
@@ -1,0 +1,76 @@
+// Role:    Windows-specific background daemon launch via scheduled task
+// Depends: fmt, os, os/exec, strings, time
+// Exports: startBackgroundDaemon
+
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/epiral/pinix/internal/pidfile"
+)
+
+const schtaskName = "PinixDaemon"
+
+// startBackgroundDaemon launches the daemon using a Windows Scheduled Task.
+//
+// On Windows, OpenSSH Server places all session processes in a Job Object with
+// "Kill on Job Close" and without "Breakaway OK". This means any child process
+// (even with DETACHED_PROCESS or CREATE_BREAKAWAY_FROM_JOB) will be killed
+// when the SSH session ends. The standard workaround is to use schtasks to
+// create a one-shot task that runs outside the SSH Job Object.
+func startBackgroundDaemon(executable string, daemonArgs []string, logFile *os.File) (int, error) {
+	_ = logFile.Close()
+
+	// Clean up any previous scheduled task
+	cleanup := exec.Command("schtasks.exe", "/Delete", "/TN", schtaskName, "/F")
+	cleanup.SysProcAttr = daemonSysProcAttr()
+	_ = cleanup.Run()
+
+	// Build the full command line for the daemon
+	args := strings.Join(daemonArgs, " ")
+
+	// Create a one-shot scheduled task that runs immediately.
+	// /SC ONCE /ST 00:00 with /Z (delete after run) is the standard pattern.
+	// /RL HIGHEST gives it admin privileges if available.
+	create := exec.Command("schtasks.exe",
+		"/Create",
+		"/TN", schtaskName,
+		"/TR", fmt.Sprintf(`"%s" %s`, executable, args),
+		"/SC", "ONCE",
+		"/ST", "00:00",
+		"/F",
+	)
+	create.SysProcAttr = daemonSysProcAttr()
+	if output, err := create.CombinedOutput(); err != nil {
+		return 0, fmt.Errorf("create scheduled task: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+
+	// Run the task immediately
+	run := exec.Command("schtasks.exe", "/Run", "/TN", schtaskName)
+	run.SysProcAttr = daemonSysProcAttr()
+	if output, err := run.CombinedOutput(); err != nil {
+		return 0, fmt.Errorf("run scheduled task: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+
+	// Wait for daemon to start and find its PID via the PID file
+	time.Sleep(3 * time.Second)
+
+	// Read PID from PID file since we can't get it from schtasks directly
+	pf, err := readPIDFileForStart()
+	if err != nil || pf == nil {
+		return 0, fmt.Errorf("daemon did not start; check ~/.pinix/logs/pinixd.log for details")
+	}
+
+	return pf.PID, nil
+}
+
+func readPIDFileForStart() (*pidfile.PIDFile, error) {
+	return pidfile.ReadPIDFile()
+}

--- a/cmd/pinix/stop.go
+++ b/cmd/pinix/stop.go
@@ -1,5 +1,5 @@
 // Role:    "stop" subcommand — stop the running Pinix daemon
-// Depends: fmt, os, syscall, time, internal/pidfile, cobra
+// Depends: fmt, os, path/filepath, strings, time, internal/pidfile, cobra
 // Exports: newStopCommand
 
 package main
@@ -7,8 +7,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/epiral/pinix/internal/pidfile"
@@ -35,8 +35,8 @@ func newStopCommand() *cobra.Command {
 			pid := pf.PID
 			resolvedPath := resolvePIDFilePath(pidPath)
 
-			// Send SIGTERM
-			if err := signalProcess(pid, syscall.SIGTERM); err != nil {
+			// Send graceful termination signal (SIGTERM on Unix, CTRL_BREAK/Kill on Windows)
+			if err := signalProcess(pid, os.Interrupt); err != nil {
 				removePIDFile(resolvedPath)
 				fmt.Println("Pinix stopped")
 				return nil
@@ -78,7 +78,7 @@ func resolvePIDFilePath(custom string) string {
 	if err != nil {
 		return ""
 	}
-	return home + "/.pinix/pinixd.pid"
+	return filepath.Join(home, ".pinix", "pinixd.pid")
 }
 
 func fileExists(path string) bool {

--- a/cmd/pinixd/daemon_signal_unix.go
+++ b/cmd/pinixd/daemon_signal_unix.go
@@ -1,0 +1,10 @@
+// Role:    Unix-specific daemon signal setup (no-op)
+// Depends: (none)
+// Exports: setupDaemonSignalHandling
+
+//go:build !windows
+
+package main
+
+// setupDaemonSignalHandling is a no-op on Unix.
+func setupDaemonSignalHandling() {}

--- a/cmd/pinixd/daemon_signal_windows.go
+++ b/cmd/pinixd/daemon_signal_windows.go
@@ -1,0 +1,18 @@
+// Role:    Windows-specific daemon signal setup — ignore console close events
+// Depends: syscall
+// Exports: setupDaemonSignalHandling
+
+//go:build windows
+
+package main
+
+import "syscall"
+
+var procSetConsoleCtrlHandler = syscall.NewLazyDLL("kernel32.dll").NewProc("SetConsoleCtrlHandler")
+
+// setupDaemonSignalHandling calls SetConsoleCtrlHandler(NULL, TRUE) to prevent
+// the daemon from being killed by CTRL_CLOSE_EVENT when the parent console
+// or SSH session closes.
+func setupDaemonSignalHandling() {
+	procSetConsoleCtrlHandler.Call(0, 1)
+}

--- a/cmd/pinixd/main.go
+++ b/cmd/pinixd/main.go
@@ -1,5 +1,5 @@
 // Role:    pinixd daemon entrypoint for Hub, Runtime, and Portal modes
-// Depends: context, flag, fmt, log/slog, net, os, os/signal, path/filepath, strings, sync, syscall, time, internal/config, internal/daemon, internal/logging, internal/pidfile
+// Depends: context, flag, fmt, log/slog, net, os, os/signal, path/filepath, strings, sync, time, internal/config, internal/daemon, internal/logging, internal/pidfile
 // Exports: main
 
 package main
@@ -15,7 +15,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	configpkg "github.com/epiral/pinix/internal/config"
@@ -118,7 +117,7 @@ func main() {
 		}
 	}
 
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
 	// PID file: prevent duplicate pinixd, enable CLI auto-discovery

--- a/cmd/pinixd/main.go
+++ b/cmd/pinixd/main.go
@@ -117,6 +117,8 @@ func main() {
 		}
 	}
 
+	setupDaemonSignalHandling()
+
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,121 @@
+# Pinix installer for Windows
+# Usage: irm dl.pinixai.com/install.ps1 | iex
+
+$ErrorActionPreference = "Stop"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$BaseUrl = "https://dl.pinixai.com/releases/latest"
+$BunMirror = "https://registry.npmmirror.com/-/binary/bun"
+$InstallDir = Join-Path $env:USERPROFILE ".pinix\bin"
+
+# Detect architecture
+$Arch = if ([Environment]::Is64BitOperatingSystem) {
+    if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "amd64" }
+} else {
+    Write-Host "Unsupported: 32-bit Windows is not supported." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "Installing Pinix (windows/$Arch)..." -ForegroundColor Cyan
+
+# Create install directory
+if (-not (Test-Path $InstallDir)) {
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+}
+
+# Download pinix.exe
+$PinixUrl = "$BaseUrl/pinix-windows-$Arch.exe"
+$PinixPath = Join-Path $InstallDir "pinix.exe"
+Write-Host "  Downloading pinix.exe..."
+try {
+    Invoke-WebRequest -Uri $PinixUrl -OutFile $PinixPath -UseBasicParsing
+} catch {
+    Write-Host "Failed to download pinix.exe from $PinixUrl" -ForegroundColor Red
+    Write-Host "  $_" -ForegroundColor Red
+    exit 1
+}
+
+# Download pinixd.exe
+$PinixdUrl = "$BaseUrl/pinixd-windows-$Arch.exe"
+$PinixdPath = Join-Path $InstallDir "pinixd.exe"
+Write-Host "  Downloading pinixd.exe..."
+try {
+    Invoke-WebRequest -Uri $PinixdUrl -OutFile $PinixdPath -UseBasicParsing
+} catch {
+    Write-Host "Failed to download pinixd.exe from $PinixdUrl" -ForegroundColor Red
+    Write-Host "  $_" -ForegroundColor Red
+    exit 1
+}
+
+# Add to user PATH if not already there
+$UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($UserPath -notlike "*$InstallDir*") {
+    [Environment]::SetEnvironmentVariable("Path", "$UserPath;$InstallDir", "User")
+    $env:Path = "$env:Path;$InstallDir"
+    Write-Host "  Added $InstallDir to PATH"
+}
+
+# Verify installation
+$Version = & $PinixPath --version 2>&1
+Write-Host "Pinix installed: $Version" -ForegroundColor Green
+
+# --- Install Bun (required for running Clips) ---
+
+$BunExe = Join-Path $env:USERPROFILE ".bun\bin\bun.exe"
+$HasBun = (Get-Command bun -ErrorAction SilentlyContinue) -or (Test-Path $BunExe)
+
+if (-not $HasBun) {
+    Write-Host ""
+    Write-Host "Installing Bun (required for Clips)..." -ForegroundColor Cyan
+
+    # Find latest bun version from npm registry
+    $BunLatest = try {
+        (Invoke-RestMethod "https://registry.npmmirror.com/bun/latest" -UseBasicParsing).version
+    } catch { "1.3.14" }  # fallback
+
+    $BunZipUrl = "$BunMirror/bun-v$BunLatest/bun-windows-x64.zip"
+    $BunZip = Join-Path $env:TEMP "bun-windows.zip"
+    $BunDir = Join-Path $env:USERPROFILE ".bun"
+    $BunBinDir = Join-Path $BunDir "bin"
+
+    Write-Host "  Downloading Bun v$BunLatest..."
+    try {
+        Invoke-WebRequest -Uri $BunZipUrl -OutFile $BunZip -UseBasicParsing
+
+        # Extract
+        $BunTmp = Join-Path $env:TEMP "bun-extract"
+        if (Test-Path $BunTmp) { Remove-Item $BunTmp -Recurse -Force }
+        Expand-Archive -Path $BunZip -DestinationPath $BunTmp -Force
+
+        # Move to ~/.bun/bin/
+        if (-not (Test-Path $BunBinDir)) {
+            New-Item -ItemType Directory -Path $BunBinDir -Force | Out-Null
+        }
+        Get-ChildItem (Join-Path $BunTmp "bun-windows-x64") | Move-Item -Destination $BunBinDir -Force
+
+        # Cleanup
+        Remove-Item $BunZip -Force -ErrorAction SilentlyContinue
+        Remove-Item $BunTmp -Recurse -Force -ErrorAction SilentlyContinue
+
+        # Add bun to PATH
+        $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+        if ($UserPath -notlike "*$BunBinDir*") {
+            [Environment]::SetEnvironmentVariable("Path", "$UserPath;$BunBinDir", "User")
+            $env:Path = "$env:Path;$BunBinDir"
+        }
+
+        $BunVersion = & $BunExe --version 2>&1
+        Write-Host "Bun installed: $BunVersion" -ForegroundColor Green
+    } catch {
+        Write-Host "Warning: Failed to install Bun automatically." -ForegroundColor Yellow
+        Write-Host "  Install manually: irm bun.sh/install.ps1 | iex"
+    }
+}
+
+Write-Host ""
+Write-Host "Get started:" -ForegroundColor Cyan
+Write-Host "  pinix start                        start Pinix"
+Write-Host "  pinix login                        log in to Pinix"
+Write-Host "  pinix hub add @pinix/todo          install your first Clip"
+Write-Host "  pinix invoke todo list             use a Clip"
+Write-Host "  Start-Process http://localhost:9000 open Console"

--- a/install.ps1
+++ b/install.ps1
@@ -1,121 +1,220 @@
 # Pinix installer for Windows
 # Usage: irm dl.pinixai.com/install.ps1 | iex
+#
+# Installs: pinix + pinixd + Bun + Node.js + bb-browser + bb-viewer (stream)
 
 $ErrorActionPreference = "Stop"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-$BaseUrl = "https://dl.pinixai.com/releases/latest"
-$BunMirror = "https://registry.npmmirror.com/-/binary/bun"
-$InstallDir = Join-Path $env:USERPROFILE ".pinix\bin"
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+$BaseUrl       = "https://dl.pinixai.com/releases/latest"
+$ViewerBaseUrl = "https://dl.pinixai.com/releases/bb-viewer/latest"
+$BunMirror     = "https://registry.npmmirror.com/-/binary/bun"
+$NodeMirror    = "https://registry.npmmirror.com/-/binary/node"
+$NpmRegistry   = "https://registry.npmmirror.com"
+
+$PinixBin  = Join-Path $env:USERPROFILE ".pinix\bin"
+$BunBin    = Join-Path $env:USERPROFILE ".bun\bin"
+$NodeDir   = Join-Path $env:USERPROFILE ".node"
+$ViewerDir = Join-Path $env:USERPROFILE ".bb-browser\bin"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+function Add-ToUserPath($dir) {
+    $p = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($p -notlike "*$dir*") {
+        [Environment]::SetEnvironmentVariable("Path", "$p;$dir", "User")
+        $env:Path = "$env:Path;$dir"
+    }
+}
+
+function Download($url, $dest, $label) {
+    Write-Host "  $label" -NoNewline
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing
+        Write-Host " done" -ForegroundColor Green
+    } catch {
+        Write-Host " FAILED" -ForegroundColor Red
+        throw "Download failed: $url`n  $_"
+    }
+}
+
+function Ensure-Dir($dir) {
+    if (-not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+}
 
 # Detect architecture
 $Arch = if ([Environment]::Is64BitOperatingSystem) {
     if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "amd64" }
 } else {
-    Write-Host "Unsupported: 32-bit Windows is not supported." -ForegroundColor Red
-    exit 1
+    Write-Host "32-bit Windows is not supported." -ForegroundColor Red; exit 1
 }
 
-Write-Host "Installing Pinix (windows/$Arch)..." -ForegroundColor Cyan
+# ===========================================================================
+# 1. Pinix (pinix.exe + pinixd.exe)
+# ===========================================================================
 
-# Create install directory
-if (-not (Test-Path $InstallDir)) {
-    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+Write-Host ""
+Write-Host "[1/5] Pinix CLI" -ForegroundColor Cyan
+Ensure-Dir $PinixBin
+
+Download "$BaseUrl/pinix-windows-$Arch.exe"  (Join-Path $PinixBin "pinix.exe")  "pinix.exe..."
+Download "$BaseUrl/pinixd-windows-$Arch.exe" (Join-Path $PinixBin "pinixd.exe") "pinixd.exe..."
+Add-ToUserPath $PinixBin
+
+$v = & (Join-Path $PinixBin "pinix.exe") --version 2>&1
+Write-Host "  $v" -ForegroundColor Green
+
+# ===========================================================================
+# 2. Bun (required for Clips)
+# ===========================================================================
+
+Write-Host ""
+Write-Host "[2/5] Bun" -ForegroundColor Cyan
+
+$BunExe = Join-Path $BunBin "bun.exe"
+if ((Get-Command bun -ErrorAction SilentlyContinue) -or (Test-Path $BunExe)) {
+    $bv = if (Test-Path $BunExe) { & $BunExe --version 2>&1 } else { & bun --version 2>&1 }
+    Write-Host "  already installed: $bv" -ForegroundColor Green
+} else {
+    $BunVer = try { (Invoke-RestMethod "$NpmRegistry/bun/latest" -UseBasicParsing).version } catch { "1.3.14" }
+    $BunZip = Join-Path $env:TEMP "bun-win.zip"
+    Download "$BunMirror/bun-v$BunVer/bun-windows-x64.zip" $BunZip "Bun v$BunVer..."
+
+    $tmp = Join-Path $env:TEMP "bun-ext"
+    if (Test-Path $tmp) { Remove-Item $tmp -Recurse -Force }
+    Expand-Archive -Path $BunZip -DestinationPath $tmp -Force
+    Ensure-Dir $BunBin
+    Get-ChildItem (Join-Path $tmp "bun-windows-x64") | Move-Item -Destination $BunBin -Force
+    Remove-Item $BunZip, $tmp -Recurse -Force -ErrorAction SilentlyContinue
+    Add-ToUserPath $BunBin
+
+    Write-Host "  Bun $(& $BunExe --version 2>&1)" -ForegroundColor Green
 }
 
-# Download pinix.exe
-$PinixUrl = "$BaseUrl/pinix-windows-$Arch.exe"
-$PinixPath = Join-Path $InstallDir "pinix.exe"
-Write-Host "  Downloading pinix.exe..."
-try {
-    Invoke-WebRequest -Uri $PinixUrl -OutFile $PinixPath -UseBasicParsing
-} catch {
-    Write-Host "Failed to download pinix.exe from $PinixUrl" -ForegroundColor Red
-    Write-Host "  $_" -ForegroundColor Red
-    exit 1
+# ===========================================================================
+# 3. Node.js (required for bb-browser)
+# ===========================================================================
+
+Write-Host ""
+Write-Host "[3/5] Node.js" -ForegroundColor Cyan
+
+$NodeExe = Join-Path $NodeDir "node.exe"
+if ((Get-Command node -ErrorAction SilentlyContinue) -or (Test-Path $NodeExe)) {
+    $nv = if (Test-Path $NodeExe) { & $NodeExe --version 2>&1 } else { & node --version 2>&1 }
+    Write-Host "  already installed: $nv" -ForegroundColor Green
+} else {
+    # Get latest LTS version
+    $NodeVer = try {
+        $listing = Invoke-RestMethod "$NodeMirror/" -UseBasicParsing
+        ($listing | Where-Object { $_.name -match '^v22\.' -and $_.type -eq 'dir' } |
+         Sort-Object { [version]($_.name -replace '^v','') } -Descending |
+         Select-Object -First 1).name -replace '/$',''
+    } catch { "v22.16.0" }
+
+    $NodeZip = Join-Path $env:TEMP "node-win.zip"
+    $NodeFolder = "node-$NodeVer-win-x64"
+    Download "$NodeMirror/$NodeVer/$NodeFolder.zip" $NodeZip "Node.js $NodeVer..."
+
+    $tmp = Join-Path $env:TEMP "node-ext"
+    if (Test-Path $tmp) { Remove-Item $tmp -Recurse -Force }
+    Expand-Archive -Path $NodeZip -DestinationPath $tmp -Force
+    if (Test-Path $NodeDir) { Remove-Item $NodeDir -Recurse -Force }
+    Move-Item (Join-Path $tmp $NodeFolder) $NodeDir -Force
+    Remove-Item $NodeZip, $tmp -Recurse -Force -ErrorAction SilentlyContinue
+    Add-ToUserPath $NodeDir
+
+    Write-Host "  Node.js $(& $NodeExe --version 2>&1)" -ForegroundColor Green
 }
 
-# Download pinixd.exe
-$PinixdUrl = "$BaseUrl/pinixd-windows-$Arch.exe"
-$PinixdPath = Join-Path $InstallDir "pinixd.exe"
-Write-Host "  Downloading pinixd.exe..."
-try {
-    Invoke-WebRequest -Uri $PinixdUrl -OutFile $PinixdPath -UseBasicParsing
-} catch {
-    Write-Host "Failed to download pinixd.exe from $PinixdUrl" -ForegroundColor Red
-    Write-Host "  $_" -ForegroundColor Red
-    exit 1
-}
+# ===========================================================================
+# 4. bb-browser (npm package)
+# ===========================================================================
 
-# Add to user PATH if not already there
-$UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
-if ($UserPath -notlike "*$InstallDir*") {
-    [Environment]::SetEnvironmentVariable("Path", "$UserPath;$InstallDir", "User")
-    $env:Path = "$env:Path;$InstallDir"
-    Write-Host "  Added $InstallDir to PATH"
-}
+Write-Host ""
+Write-Host "[4/5] bb-browser" -ForegroundColor Cyan
 
-# Verify installation
-$Version = & $PinixPath --version 2>&1
-Write-Host "Pinix installed: $Version" -ForegroundColor Green
+# Resolve npm path
+$NpmCmd = if (Test-Path (Join-Path $NodeDir "npm.cmd")) {
+    Join-Path $NodeDir "npm.cmd"
+} elseif (Get-Command npm -ErrorAction SilentlyContinue) {
+    "npm"
+} else { $null }
 
-# --- Install Bun (required for running Clips) ---
-
-$BunExe = Join-Path $env:USERPROFILE ".bun\bin\bun.exe"
-$HasBun = (Get-Command bun -ErrorAction SilentlyContinue) -or (Test-Path $BunExe)
-
-if (-not $HasBun) {
-    Write-Host ""
-    Write-Host "Installing Bun (required for Clips)..." -ForegroundColor Cyan
-
-    # Find latest bun version from npm registry
-    $BunLatest = try {
-        (Invoke-RestMethod "https://registry.npmmirror.com/bun/latest" -UseBasicParsing).version
-    } catch { "1.3.14" }  # fallback
-
-    $BunZipUrl = "$BunMirror/bun-v$BunLatest/bun-windows-x64.zip"
-    $BunZip = Join-Path $env:TEMP "bun-windows.zip"
-    $BunDir = Join-Path $env:USERPROFILE ".bun"
-    $BunBinDir = Join-Path $BunDir "bin"
-
-    Write-Host "  Downloading Bun v$BunLatest..."
-    try {
-        Invoke-WebRequest -Uri $BunZipUrl -OutFile $BunZip -UseBasicParsing
-
-        # Extract
-        $BunTmp = Join-Path $env:TEMP "bun-extract"
-        if (Test-Path $BunTmp) { Remove-Item $BunTmp -Recurse -Force }
-        Expand-Archive -Path $BunZip -DestinationPath $BunTmp -Force
-
-        # Move to ~/.bun/bin/
-        if (-not (Test-Path $BunBinDir)) {
-            New-Item -ItemType Directory -Path $BunBinDir -Force | Out-Null
-        }
-        Get-ChildItem (Join-Path $BunTmp "bun-windows-x64") | Move-Item -Destination $BunBinDir -Force
-
-        # Cleanup
-        Remove-Item $BunZip -Force -ErrorAction SilentlyContinue
-        Remove-Item $BunTmp -Recurse -Force -ErrorAction SilentlyContinue
-
-        # Add bun to PATH
-        $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
-        if ($UserPath -notlike "*$BunBinDir*") {
-            [Environment]::SetEnvironmentVariable("Path", "$UserPath;$BunBinDir", "User")
-            $env:Path = "$env:Path;$BunBinDir"
-        }
-
-        $BunVersion = & $BunExe --version 2>&1
-        Write-Host "Bun installed: $BunVersion" -ForegroundColor Green
-    } catch {
-        Write-Host "Warning: Failed to install Bun automatically." -ForegroundColor Yellow
-        Write-Host "  Install manually: irm bun.sh/install.ps1 | iex"
+if (-not $NpmCmd) {
+    Write-Host "  skipped: npm not found" -ForegroundColor Yellow
+} else {
+    $bbVer = try { & $NpmCmd list -g bb-browser --depth=0 2>&1 | Select-String "bb-browser@" } catch { $null }
+    if ($bbVer) {
+        Write-Host "  already installed: $($bbVer.ToString().Trim())" -ForegroundColor Green
+    } else {
+        Write-Host "  installing via npm..."
+        & $NpmCmd install -g bb-browser --registry $NpmRegistry 2>&1 | Out-Null
+        $bbv = try { & (Join-Path $NodeDir "bb-browser.cmd") --version 2>&1 } catch { "installed" }
+        Write-Host "  bb-browser $bbv" -ForegroundColor Green
     }
 }
 
+# ===========================================================================
+# 5. bb-viewer / stream (pre-built binary + DLLs)
+# ===========================================================================
+
+Write-Host ""
+Write-Host "[5/5] bb-viewer (stream)" -ForegroundColor Cyan
+
+Ensure-Dir $ViewerDir
+
+$viewerExe = Join-Path $ViewerDir "bb-viewer.exe"
+if (Test-Path $viewerExe) {
+    Write-Host "  already installed" -ForegroundColor Green
+} else {
+    $files = @(
+        @{ name = "bb-viewer-windows-amd64.exe"; dest = "bb-viewer.exe" },
+        @{ name = "bb-viewer-windows-amd64.exe"; dest = "bb-viewer" },  # alias without .exe for Node spawn
+        @{ name = "libturbojpeg.dll";            dest = "libturbojpeg.dll" },
+        @{ name = "libvpx-1.dll";                dest = "libvpx-1.dll" },
+        @{ name = "libgcc_s_seh-1.dll";          dest = "libgcc_s_seh-1.dll" },
+        @{ name = "libwinpthread-1.dll";         dest = "libwinpthread-1.dll" }
+    )
+    foreach ($f in $files) {
+        Download "$ViewerBaseUrl/$($f.name)" (Join-Path $ViewerDir $f.dest) "$($f.dest)..."
+    }
+
+    # DLLs also need to be findable by the system loader when Node spawns bb-viewer
+    $sysDlls = @("libturbojpeg.dll", "libvpx-1.dll", "libgcc_s_seh-1.dll", "libwinpthread-1.dll")
+    foreach ($dll in $sysDlls) {
+        $src = Join-Path $ViewerDir $dll
+        $dst = Join-Path $env:SystemRoot "System32\$dll"
+        if (-not (Test-Path $dst)) {
+            try { Copy-Item $src $dst -Force } catch {
+                # Not admin — add viewer dir to PATH instead
+                Add-ToUserPath $ViewerDir
+                break
+            }
+        }
+    }
+
+    Write-Host "  bb-viewer installed" -ForegroundColor Green
+}
+
+# ===========================================================================
+# Done
+# ===========================================================================
+
+Write-Host ""
+Write-Host "Pinix installed successfully!" -ForegroundColor Green
 Write-Host ""
 Write-Host "Get started:" -ForegroundColor Cyan
-Write-Host "  pinix start                        start Pinix"
-Write-Host "  pinix login                        log in to Pinix"
+Write-Host "  pinix start                        start the daemon"
+Write-Host "  pinix login                        log in to Pinix Cloud"
 Write-Host "  pinix hub add @pinix/todo          install your first Clip"
 Write-Host "  pinix invoke todo list             use a Clip"
-Write-Host "  Start-Process http://localhost:9000 open Console"
+Write-Host ""
+Write-Host "Note: restart your terminal for PATH changes to take effect." -ForegroundColor Yellow

--- a/internal/daemon/install.go
+++ b/internal/daemon/install.go
@@ -274,7 +274,12 @@ func extractTarGz(targetPath string, data []byte) error {
 				return fmt.Errorf("create tarball symlink parent %s: %w", filepath.Dir(target), err)
 			}
 			if err := os.Symlink(header.Linkname, target); err != nil {
-				return fmt.Errorf("create tarball symlink %s: %w", target, err)
+				// Symlinks may fail on Windows without admin/Developer Mode.
+				// Fall back to copying the link target.
+				linkSrc := filepath.Join(filepath.Dir(target), header.Linkname)
+				if copyErr := copyFileIfExists(linkSrc, target); copyErr != nil {
+					return fmt.Errorf("create tarball symlink %s (and copy fallback failed): %w", target, err)
+				}
 			}
 		}
 	}
@@ -313,7 +318,15 @@ func copyDirectory(sourceDir, targetDir string) error {
 			if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
 				return err
 			}
-			return os.Symlink(linkTarget, targetPath)
+			if err := os.Symlink(linkTarget, targetPath); err != nil {
+				// Symlinks may fail on Windows without admin/Developer Mode.
+				// Fall back to copying the link target.
+				linkSrc := filepath.Join(filepath.Dir(path), linkTarget)
+				if copyErr := copyFileIfExists(linkSrc, targetPath); copyErr != nil {
+					return fmt.Errorf("symlink %s (and copy fallback failed): %w", targetPath, err)
+				}
+			}
+			return nil
 		}
 		if entry.IsDir() {
 			return os.MkdirAll(targetPath, info.Mode().Perm())
@@ -323,6 +336,18 @@ func copyDirectory(sourceDir, targetDir string) error {
 		}
 		return copyFile(path, targetPath, info.Mode().Perm())
 	})
+}
+
+// copyFileIfExists copies a file if the source exists, used as a fallback when symlinks fail (e.g. on Windows).
+func copyFileIfExists(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return copyDirectory(src, dst)
+	}
+	return copyFile(src, dst, info.Mode().Perm())
 }
 
 func copyFile(sourcePath, targetPath string, mode fs.FileMode) error {

--- a/internal/daemon/process.go
+++ b/internal/daemon/process.go
@@ -1,5 +1,5 @@
 // Role:    Bun Clip process lifecycle, IPC registration handshake, and Clip invocation router
-// Depends: bufio, context, crypto/rand, encoding/hex, encoding/json, errors, fmt, io, log/slog, os, os/exec, path/filepath, sort, strconv, strings, sync, sync/atomic, syscall, time, connectrpc, internal/client, internal/ipc
+// Depends: bufio, context, crypto/rand, encoding/hex, encoding/json, errors, fmt, io, log/slog, os, os/exec, path/filepath, runtime, sort, strconv, strings, sync, sync/atomic, time, connectrpc, internal/client, internal/ipc
 // Exports: ProcessManager, NewProcessManager
 
 package daemon
@@ -19,10 +19,10 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	connect "connectrpc.com/connect"
@@ -1242,8 +1242,8 @@ func stopProcess(proc *clipProcess, timeout time.Duration) error {
 		return nil
 	}
 
-	if err := proc.cmd.Process.Signal(syscall.SIGTERM); err != nil && !errors.Is(err, os.ErrProcessDone) {
-		return fmt.Errorf("send SIGTERM: %w", err)
+	if err := sendTermSignal(proc.cmd.Process); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("send term signal: %w", err)
 	}
 
 	select {
@@ -1274,12 +1274,18 @@ func findBunBinary() (string, error) {
 		return "", fmt.Errorf("get home dir for bun lookup: %w", err)
 	}
 
-	candidate := filepath.Join(home, ".bun", "bin", "bun")
+	// On Windows, bun installs as bun.exe
+	bunName := "bun"
+	if runtime.GOOS == "windows" {
+		bunName = "bun.exe"
+	}
+
+	candidate := filepath.Join(home, ".bun", "bin", bunName)
 	if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
 		return candidate, nil
 	}
 
-	return "", fmt.Errorf("bun binary not found in PATH or ~/.bun/bin/bun")
+	return "", fmt.Errorf("bun binary not found in PATH or ~/%s", filepath.Join(".bun", "bin", bunName))
 }
 
 func resolveEntrypoint(clip ClipConfig) (string, error) {

--- a/internal/daemon/process_signal_unix.go
+++ b/internal/daemon/process_signal_unix.go
@@ -1,0 +1,17 @@
+// Role:    Unix-specific process signal helpers for Clip process management
+// Depends: os, syscall
+// Exports: sendTermSignal
+
+//go:build !windows
+
+package daemon
+
+import (
+	"os"
+	"syscall"
+)
+
+// sendTermSignal sends SIGTERM to the process for graceful shutdown.
+func sendTermSignal(proc *os.Process) error {
+	return proc.Signal(syscall.SIGTERM)
+}

--- a/internal/daemon/process_signal_windows.go
+++ b/internal/daemon/process_signal_windows.go
@@ -1,0 +1,15 @@
+// Role:    Windows-specific process signal helpers for Clip process management
+// Depends: os
+// Exports: sendTermSignal
+
+//go:build windows
+
+package daemon
+
+import "os"
+
+// sendTermSignal on Windows directly kills the process since Windows does not
+// support SIGTERM. The caller will still respect the graceful shutdown timeout.
+func sendTermSignal(proc *os.Process) error {
+	return proc.Kill()
+}

--- a/internal/daemon/registry.go
+++ b/internal/daemon/registry.go
@@ -1,5 +1,5 @@
 // Role:    File-locked config registry for Pinix daemon state
-// Depends: encoding/json, fmt, os, path/filepath, sort, strings, syscall
+// Depends: encoding/json, fmt, os, path/filepath, sort, strings
 // Exports: ClipConfig, CommandInfo, DependencySpec, ManifestCache, Config, Registry, DefaultRootDir, DefaultConfigPath, NewRegistry
 
 package daemon
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"syscall"
 )
 
 type ClipConfig struct {
@@ -181,20 +180,16 @@ func (r *Registry) withConfig(exclusive bool, fn func(cfg *Config) error) error 
 		return err
 	}
 
-	lockFile, err := os.OpenFile(r.lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	lf, err := os.OpenFile(r.lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return fmt.Errorf("open config lock: %w", err)
 	}
-	defer lockFile.Close()
+	defer lf.Close()
 
-	mode := syscall.LOCK_SH
-	if exclusive {
-		mode = syscall.LOCK_EX
-	}
-	if err := syscall.Flock(int(lockFile.Fd()), mode); err != nil {
+	if err := lockFile(lf, exclusive); err != nil {
 		return fmt.Errorf("lock config: %w", err)
 	}
-	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+	defer unlockFile(lf)
 
 	cfg, err := r.loadLocked()
 	if err != nil {

--- a/internal/daemon/registry_flock_unix.go
+++ b/internal/daemon/registry_flock_unix.go
@@ -1,0 +1,24 @@
+// Role:    Unix file locking via syscall.Flock
+// Depends: os, syscall
+// Exports: lockFile, unlockFile
+
+//go:build !windows
+
+package daemon
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockFile(f *os.File, exclusive bool) error {
+	mode := syscall.LOCK_SH
+	if exclusive {
+		mode = syscall.LOCK_EX
+	}
+	return syscall.Flock(int(f.Fd()), mode)
+}
+
+func unlockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/internal/daemon/registry_flock_windows.go
+++ b/internal/daemon/registry_flock_windows.go
@@ -1,0 +1,59 @@
+// Role:    Windows file locking via LockFileEx / UnlockFileEx
+// Depends: os, syscall, unsafe
+// Exports: lockFile, unlockFile
+
+//go:build windows
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	modkernel32     = syscall.NewLazyDLL("kernel32.dll")
+	procLockFileEx  = modkernel32.NewProc("LockFileEx")
+	procUnlockFileEx = modkernel32.NewProc("UnlockFileEx")
+)
+
+const (
+	lockfileExclusiveLock = 0x00000002
+	lockfileFailImmediately = 0x00000001
+)
+
+func lockFile(f *os.File, exclusive bool) error {
+	var flags uint32
+	if exclusive {
+		flags = lockfileExclusiveLock
+	}
+
+	ol := new(syscall.Overlapped)
+	ret, _, err := procLockFileEx.Call(
+		uintptr(f.Fd()),
+		uintptr(flags),
+		0,
+		1, 0,
+		uintptr(unsafe.Pointer(ol)),
+	)
+	if ret == 0 {
+		return fmt.Errorf("LockFileEx: %w", err)
+	}
+	return nil
+}
+
+func unlockFile(f *os.File) error {
+	ol := new(syscall.Overlapped)
+	ret, _, err := procUnlockFileEx.Call(
+		uintptr(f.Fd()),
+		0,
+		1, 0,
+		uintptr(unsafe.Pointer(ol)),
+	)
+	if ret == 0 {
+		return fmt.Errorf("UnlockFileEx: %w", err)
+	}
+	return nil
+}

--- a/internal/pidfile/pidfile.go
+++ b/internal/pidfile/pidfile.go
@@ -1,5 +1,5 @@
 // Role:    PID file management for pinixd — write, read, validate, and clean stale PID files
-// Depends: encoding/json, fmt, os, path/filepath, strings, syscall, time
+// Depends: encoding/json, fmt, os, path/filepath, strings, time
 // Exports: PIDFile, WritePIDFile, ReadPIDFile, CheckExistingPIDFile
 
 package pidfile
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
 	"time"
 )
 
@@ -113,13 +112,13 @@ func ReadPIDFile(customPath ...string) (*PIDFile, error) {
 		return nil, nil
 	}
 
-	// Check if process is still alive (signal 0 = no-op, just checks existence).
+	// Check if process is still alive.
 	proc, err := os.FindProcess(pf.PID)
 	if err != nil {
 		_ = os.Remove(path)
 		return nil, nil
 	}
-	if err := proc.Signal(syscall.Signal(0)); err != nil {
+	if !isProcessAlive(proc) {
 		// Process is dead — remove stale file
 		_ = os.Remove(path)
 		return nil, nil

--- a/internal/pidfile/pidfile_unix.go
+++ b/internal/pidfile/pidfile_unix.go
@@ -1,0 +1,17 @@
+// Role:    Unix-specific process liveness check for PID file validation
+// Depends: os, syscall
+// Exports: isProcessAlive
+
+//go:build !windows
+
+package pidfile
+
+import (
+	"os"
+	"syscall"
+)
+
+// isProcessAlive checks if a process is alive using signal 0.
+func isProcessAlive(proc *os.Process) bool {
+	return proc.Signal(syscall.Signal(0)) == nil
+}

--- a/internal/pidfile/pidfile_windows.go
+++ b/internal/pidfile/pidfile_windows.go
@@ -1,0 +1,30 @@
+// Role:    Windows-specific process liveness check for PID file validation
+// Depends: os, syscall
+// Exports: isProcessAlive
+
+//go:build windows
+
+package pidfile
+
+import (
+	"os"
+	"syscall"
+)
+
+var procOpenProcess = syscall.NewLazyDLL("kernel32.dll").NewProc("OpenProcess")
+
+const processQueryLimitedInfo = 0x1000
+
+// isProcessAlive checks if a process is alive using OpenProcess.
+func isProcessAlive(proc *os.Process) bool {
+	h, _, _ := procOpenProcess.Call(
+		uintptr(processQueryLimitedInfo),
+		0,
+		uintptr(proc.Pid),
+	)
+	if h == 0 {
+		return false
+	}
+	syscall.CloseHandle(syscall.Handle(h))
+	return true
+}


### PR DESCRIPTION
## Summary

让 `pinixd` 和 `pinix` CLI 能在 Windows 上编译和运行。

## Changes

### 新文件 (9 个平台文件)

| 文件 | 用途 |
|---|---|
| `cmd/pinix/process_windows.go` | `daemonSysProcAttr`, `checkProcessAlive`, `signalProcess` 的 Windows 实现 |
| `cmd/pinix/daemon_process_unix.go` | bb-browser 进程组管理 (Unix: Setpgid + Kill(-pid)) |
| `cmd/pinix/daemon_process_windows.go` | bb-browser 进程组管理 (Windows: CREATE_NEW_PROCESS_GROUP) |
| `internal/daemon/registry_flock_unix.go` | 文件锁 (Unix: syscall.Flock) |
| `internal/daemon/registry_flock_windows.go` | 文件锁 (Windows: LockFileEx/UnlockFileEx) |
| `internal/daemon/process_signal_unix.go` | Clip 进程终止 (Unix: SIGTERM) |
| `internal/daemon/process_signal_windows.go` | Clip 进程终止 (Windows: Kill) |
| `internal/pidfile/pidfile_unix.go` | 进程活性检查 (Unix: Signal(0)) |
| `internal/pidfile/pidfile_windows.go` | 进程活性检查 (Windows: OpenProcess) |

### 修改文件 (8 个)

- **registry.go**: 去掉 `syscall.Flock`，改用跨平台 `lockFile`/`unlockFile`
- **daemon.go**: 去掉 `syscall.Kill(-pid)`, `Setpgid`, `SIGTERM`，改用平台函数
- **process.go**: `stopProcess` 用 `sendTermSignal`；`findBunBinary` 加 `.exe` 和 Windows 路径
- **pidfile.go**: `Signal(0)` 改用 `isProcessAlive`
- **main.go (pinixd)**: `signal.NotifyContext` 用 `os.Interrupt` 替代 `syscall.SIGTERM`
- **stop.go**: 用 `filepath.Join` 替代手动 `/` 拼接；用 `os.Interrupt` 替代 `syscall.SIGTERM`
- **install.go**: symlink 失败时 fallback 到复制文件（Windows 无 Developer Mode 时需要）
- **Makefile**: 加 `windows/amd64` 构建目标

## Verification

```bash
# Windows cross-compilation
GOOS=windows GOARCH=amd64 go build ./cmd/pinix   ✅
GOOS=windows GOARCH=amd64 go build ./cmd/pinixd  ✅
GOOS=windows GOARCH=amd64 go vet ./...           ✅

# Native (macOS) still works
go build ./cmd/pinix && go build ./cmd/pinixd     ✅
go vet ./...                                       ✅
go test ./...                                      ✅

# Linux cross-compilation
GOOS=linux GOARCH=amd64 go build ./cmd/pinix      ✅
GOOS=linux GOARCH=arm64 go build ./cmd/pinixd     ✅
```

Closes #132