### PR TITLE
feat(scheduler): add cron-based scheduled task system

### DIFF
--- a/cmd/pinix/main.go
+++ b/cmd/pinix/main.go
@@ -72,6 +72,7 @@ Docker:
 	rootCmd.AddCommand(newHubCommand())
 	rootCmd.AddCommand(newRegistryGroupCommand())
 	rootCmd.AddCommand(newConfigCommand())
+	rootCmd.AddCommand(newScheduleCommand())
 	rootCmd.AddCommand(newUpgradeCommand())
 
 	return rootCmd

--- a/cmd/pinix/schedule.go
+++ b/cmd/pinix/schedule.go
@@ -1,0 +1,261 @@
+// Role:    Schedule subcommand group — manage scheduled Clip invocations
+// Depends: fmt, strings, internal/client, cobra
+// Exports: newScheduleCommand
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/epiral/pinix/internal/client"
+	"github.com/spf13/cobra"
+)
+
+func newScheduleCommand() *cobra.Command {
+	var serverURL string
+	var hubToken string
+
+	cmd := &cobra.Command{
+		Use:   "schedule",
+		Short: "Manage scheduled Clip invocations",
+		Long: `Create, list, and manage scheduled (cron) invocations of Clips.
+
+Examples:
+  pinix schedule list
+  pinix schedule add morning-digest lark-im search --cron "0 9 * * *" --input '{"query":"unread"}'
+  pinix schedule pause morning-digest
+  pinix schedule resume morning-digest
+  pinix schedule run morning-digest
+  pinix schedule history morning-digest
+  pinix schedule remove morning-digest`,
+	}
+	cmd.PersistentFlags().StringVar(&serverURL, "server", defaultHubURL(), "Hub URL (default: auto-discover)")
+	cmd.PersistentFlags().StringVar(&hubToken, "auth-token", defaultHubToken(), "Hub auth token")
+
+	cmd.AddCommand(newScheduleListCommand(&serverURL, &hubToken))
+	cmd.AddCommand(newScheduleAddCommand(&serverURL, &hubToken))
+	cmd.AddCommand(newScheduleRemoveCommand(&serverURL, &hubToken))
+	cmd.AddCommand(newSchedulePauseCommand(&serverURL, &hubToken))
+	cmd.AddCommand(newScheduleResumeCommand(&serverURL, &hubToken))
+	cmd.AddCommand(newScheduleRunCommand(&serverURL, &hubToken))
+	cmd.AddCommand(newScheduleHistoryCommand(&serverURL, &hubToken))
+
+	return cmd
+}
+
+func newScheduleListCommand(serverURL, hubToken *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all scheduled tasks",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cli, err := client.New(*serverURL)
+			if err != nil {
+				return err
+			}
+			schedules, err := cli.ListSchedules(cmd.Context(), *hubToken)
+			if err != nil {
+				return err
+			}
+			if len(schedules) == 0 {
+				fmt.Println("(no scheduled tasks)")
+				return nil
+			}
+			for _, s := range schedules {
+				rule := s.GetRule()
+				status := "enabled"
+				if !rule.GetEnabled() {
+					status = "paused"
+				}
+				nextRun := "-"
+				if s.GetNextRun() != "" {
+					nextRun = s.GetNextRun()
+				}
+				lastResult := "-"
+				if s.GetLastRun() != nil {
+					if s.GetLastRun().GetSuccess() {
+						lastResult = "ok"
+					} else {
+						lastResult = "fail"
+					}
+				}
+				fmt.Printf("%s\t%s\t%s\t%s\t%s\tnext:%s\tlast:%s\n",
+					rule.GetId(),
+					rule.GetClip(),
+					rule.GetCommand(),
+					rule.GetCron(),
+					status,
+					nextRun,
+					lastResult,
+				)
+			}
+			return nil
+		},
+	}
+}
+
+func newScheduleAddCommand(serverURL, hubToken *string) *cobra.Command {
+	var cronExpr string
+	var input string
+	var description string
+
+	cmd := &cobra.Command{
+		Use:   "add <id> <clip> <command>",
+		Short: "Create a scheduled task",
+		Long: `Create a new scheduled Clip invocation.
+
+The id is a user-chosen name for this schedule (e.g., "morning-digest").
+The cron expression follows standard cron format: minute hour day-of-month month day-of-week.
+
+Examples:
+  pinix schedule add morning-digest lark-im search --cron "0 9 * * *"
+  pinix schedule add sync-check store push --cron "*/5 * * * *" --input '{"force":true}'`,
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := strings.TrimSpace(args[0])
+			clip := strings.TrimSpace(args[1])
+			command := strings.TrimSpace(args[2])
+
+			if cronExpr == "" {
+				return fmt.Errorf("--cron is required")
+			}
+
+			cli, err := client.New(*serverURL)
+			if err != nil {
+				return err
+			}
+			rule, err := cli.AddSchedule(cmd.Context(), id, clip, command, cronExpr, input, description, *hubToken)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("created schedule %q: %s %s [%s]\n", rule.GetId(), rule.GetClip(), rule.GetCommand(), rule.GetCron())
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&cronExpr, "cron", "", "cron expression (required)")
+	cmd.Flags().StringVar(&input, "input", "", "JSON input for the command")
+	cmd.Flags().StringVar(&description, "desc", "", "human-readable description")
+	return cmd
+}
+
+func newScheduleRemoveCommand(serverURL, hubToken *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove <id>",
+		Short: "Remove a scheduled task",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := strings.TrimSpace(args[0])
+			cli, err := client.New(*serverURL)
+			if err != nil {
+				return err
+			}
+			if err := cli.RemoveSchedule(cmd.Context(), id, *hubToken); err != nil {
+				return err
+			}
+			fmt.Printf("removed schedule %q\n", id)
+			return nil
+		},
+	}
+}
+
+func newSchedulePauseCommand(serverURL, hubToken *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "pause <id>",
+		Short: "Pause a scheduled task",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := strings.TrimSpace(args[0])
+			cli, err := client.New(*serverURL)
+			if err != nil {
+				return err
+			}
+			if err := cli.PauseSchedule(cmd.Context(), id, *hubToken); err != nil {
+				return err
+			}
+			fmt.Printf("paused schedule %q\n", id)
+			return nil
+		},
+	}
+}
+
+func newScheduleResumeCommand(serverURL, hubToken *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "resume <id>",
+		Short: "Resume a paused scheduled task",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := strings.TrimSpace(args[0])
+			cli, err := client.New(*serverURL)
+			if err != nil {
+				return err
+			}
+			if err := cli.ResumeSchedule(cmd.Context(), id, *hubToken); err != nil {
+				return err
+			}
+			fmt.Printf("resumed schedule %q\n", id)
+			return nil
+		},
+	}
+}
+
+func newScheduleRunCommand(serverURL, hubToken *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "run <id>",
+		Short: "Trigger a scheduled task immediately",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := strings.TrimSpace(args[0])
+			cli, err := client.New(*serverURL)
+			if err != nil {
+				return err
+			}
+			if err := cli.RunSchedule(cmd.Context(), id, *hubToken); err != nil {
+				return err
+			}
+			fmt.Printf("triggered schedule %q\n", id)
+			return nil
+		},
+	}
+}
+
+func newScheduleHistoryCommand(serverURL, hubToken *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "history <id>",
+		Short: "Show execution history for a scheduled task",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := strings.TrimSpace(args[0])
+			cli, err := client.New(*serverURL)
+			if err != nil {
+				return err
+			}
+			executions, err := cli.GetScheduleHistory(cmd.Context(), id, *hubToken)
+			if err != nil {
+				return err
+			}
+			if len(executions) == 0 {
+				fmt.Println("(no executions)")
+				return nil
+			}
+			for _, e := range executions {
+				status := "ok"
+				if !e.GetSuccess() {
+					status = "FAIL"
+				}
+				errMsg := ""
+				if e.GetError() != "" {
+					errMsg = " error=" + e.GetError()
+				}
+				fmt.Printf("%s  %s  %dms  %s%s\n",
+					e.GetStartedAt(),
+					e.GetScheduleId(),
+					e.GetDurationMs(),
+					status,
+					errMsg,
+				)
+			}
+			return nil
+		},
+	}
+}

--- a/cmd/pinixd/main.go
+++ b/cmd/pinixd/main.go
@@ -157,6 +157,15 @@ func main() {
 			exitErr(err)
 		}
 		defer func() { _ = d.Close() }()
+
+		// Start scheduler (invokes through external Hub)
+		sched := daemon.NewScheduler(registry, hubURL)
+		sched.SetHubToken(hubToken)
+		d.SetScheduler(sched)
+		if err := sched.Start(); err != nil {
+			slog.Warn("scheduler: failed to start", "error", err)
+		}
+
 		if err := d.ConnectHub(ctx, hubURL, port, hubToken); err != nil {
 			exitErr(err)
 		}
@@ -167,10 +176,17 @@ func main() {
 	addr := fmt.Sprintf(":%d", port)
 	localHubURL := fmt.Sprintf("http://127.0.0.1:%d", port)
 
-	// Start Hub
+	// Start Hub (also hosts the scheduler so RPC handlers can reach it)
 	hubDaemon, err := daemon.NewHubDaemon(registry)
 	if err != nil {
 		exitErr(err)
+	}
+
+	// Start scheduler on hubDaemon (invokes through local Hub)
+	sched := daemon.NewScheduler(registry, localHubURL)
+	hubDaemon.SetScheduler(sched)
+	if err := sched.Start(); err != nil {
+		slog.Warn("scheduler: failed to start", "error", err)
 	}
 
 	var wg sync.WaitGroup

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 require (
 	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/modelcontextprotocol/go-sdk v1.4.1 h1:M4x9GyIPj+HoIlHNGpK2hq5o3BFhC+78PkEaldQRphc=
 github.com/modelcontextprotocol/go-sdk v1.4.1/go.mod h1:Bo/mS87hPQqHSRkMv4dQq1XCu6zv4INdXnFZabkNU6s=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -244,6 +244,73 @@ func setAuthHeader(header http.Header, token string) {
 	header.Set("Authorization", "Bearer "+token)
 }
 
+// --- Schedule methods ---
+
+func (c *Client) ListSchedules(ctx context.Context, hubToken string) ([]*pinixv2.ScheduleStatus, error) {
+	req := connect.NewRequest(&pinixv2.ListSchedulesRequest{})
+	setAuthHeader(req.Header(), hubToken)
+	resp, err := c.hub.ListSchedules(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg.GetSchedules(), nil
+}
+
+func (c *Client) AddSchedule(ctx context.Context, id, clip, command, cronExpr, input, description, hubToken string) (*pinixv2.ScheduleRule, error) {
+	req := connect.NewRequest(&pinixv2.AddScheduleRequest{
+		Id:          id,
+		Clip:        clip,
+		Command:     command,
+		Cron:        cronExpr,
+		Input:       input,
+		Description: description,
+	})
+	setAuthHeader(req.Header(), hubToken)
+	resp, err := c.hub.AddSchedule(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg.GetRule(), nil
+}
+
+func (c *Client) RemoveSchedule(ctx context.Context, id, hubToken string) error {
+	req := connect.NewRequest(&pinixv2.RemoveScheduleRequest{Id: id})
+	setAuthHeader(req.Header(), hubToken)
+	_, err := c.hub.RemoveSchedule(ctx, req)
+	return err
+}
+
+func (c *Client) PauseSchedule(ctx context.Context, id, hubToken string) error {
+	req := connect.NewRequest(&pinixv2.PauseScheduleRequest{Id: id})
+	setAuthHeader(req.Header(), hubToken)
+	_, err := c.hub.PauseSchedule(ctx, req)
+	return err
+}
+
+func (c *Client) ResumeSchedule(ctx context.Context, id, hubToken string) error {
+	req := connect.NewRequest(&pinixv2.ResumeScheduleRequest{Id: id})
+	setAuthHeader(req.Header(), hubToken)
+	_, err := c.hub.ResumeSchedule(ctx, req)
+	return err
+}
+
+func (c *Client) RunSchedule(ctx context.Context, id, hubToken string) error {
+	req := connect.NewRequest(&pinixv2.RunScheduleRequest{Id: id})
+	setAuthHeader(req.Header(), hubToken)
+	_, err := c.hub.RunSchedule(ctx, req)
+	return err
+}
+
+func (c *Client) GetScheduleHistory(ctx context.Context, id, hubToken string) ([]*pinixv2.ScheduleExecution, error) {
+	req := connect.NewRequest(&pinixv2.GetScheduleHistoryRequest{Id: id})
+	setAuthHeader(req.Header(), hubToken)
+	resp, err := c.hub.GetScheduleHistory(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg.GetExecutions(), nil
+}
+
 func protoHubError(err *pinixv2.HubError) error {
 	if err == nil {
 		return nil

--- a/internal/daemon/connect.go
+++ b/internal/daemon/connect.go
@@ -1316,3 +1316,184 @@ func (h *HubService) resolveClipName(name string) (string, error) {
 		}
 	}
 }
+
+// ============================================================
+//  Schedule RPCs
+// ============================================================
+
+func (h *HubService) requireScheduler() (*Scheduler, error) {
+	if h.daemon == nil || h.daemon.scheduler == nil {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("scheduler is not available"))
+	}
+	return h.daemon.scheduler, nil
+}
+
+func (h *HubService) ListSchedules(ctx context.Context, req *connect.Request[pinixv2.ListSchedulesRequest]) (*connect.Response[pinixv2.ListSchedulesResponse], error) {
+	sched, err := h.requireScheduler()
+	if err != nil {
+		return nil, err
+	}
+	statuses, err := sched.List()
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	pbStatuses := make([]*pinixv2.ScheduleStatus, 0, len(statuses))
+	for _, s := range statuses {
+		pbStatuses = append(pbStatuses, scheduleStatusToProto(s))
+	}
+	return connect.NewResponse(&pinixv2.ListSchedulesResponse{
+		Schedules: pbStatuses,
+	}), nil
+}
+
+func (h *HubService) AddSchedule(ctx context.Context, req *connect.Request[pinixv2.AddScheduleRequest]) (*connect.Response[pinixv2.AddScheduleResponse], error) {
+	sched, err := h.requireScheduler()
+	if err != nil {
+		return nil, err
+	}
+	sc := ScheduleConfig{
+		ID:          strings.TrimSpace(req.Msg.GetId()),
+		Clip:        strings.TrimSpace(req.Msg.GetClip()),
+		Command:     strings.TrimSpace(req.Msg.GetCommand()),
+		Cron:        strings.TrimSpace(req.Msg.GetCron()),
+		Input:       req.Msg.GetInput(),
+		Description: req.Msg.GetDescription(),
+		Enabled:     true,
+	}
+	if sc.ID == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("id is required"))
+	}
+	if sc.Clip == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("clip is required"))
+	}
+	if sc.Command == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("command is required"))
+	}
+	if sc.Cron == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("cron is required"))
+	}
+	if err := sched.Add(sc); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	return connect.NewResponse(&pinixv2.AddScheduleResponse{
+		Rule: scheduleConfigToProto(sc),
+	}), nil
+}
+
+func (h *HubService) RemoveSchedule(ctx context.Context, req *connect.Request[pinixv2.RemoveScheduleRequest]) (*connect.Response[pinixv2.RemoveScheduleResponse], error) {
+	sched, err := h.requireScheduler()
+	if err != nil {
+		return nil, err
+	}
+	id := strings.TrimSpace(req.Msg.GetId())
+	if id == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("id is required"))
+	}
+	if err := sched.Remove(id); err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	return connect.NewResponse(&pinixv2.RemoveScheduleResponse{}), nil
+}
+
+func (h *HubService) PauseSchedule(ctx context.Context, req *connect.Request[pinixv2.PauseScheduleRequest]) (*connect.Response[pinixv2.PauseScheduleResponse], error) {
+	sched, err := h.requireScheduler()
+	if err != nil {
+		return nil, err
+	}
+	id := strings.TrimSpace(req.Msg.GetId())
+	if id == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("id is required"))
+	}
+	if err := sched.Pause(id); err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	return connect.NewResponse(&pinixv2.PauseScheduleResponse{}), nil
+}
+
+func (h *HubService) ResumeSchedule(ctx context.Context, req *connect.Request[pinixv2.ResumeScheduleRequest]) (*connect.Response[pinixv2.ResumeScheduleResponse], error) {
+	sched, err := h.requireScheduler()
+	if err != nil {
+		return nil, err
+	}
+	id := strings.TrimSpace(req.Msg.GetId())
+	if id == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("id is required"))
+	}
+	if err := sched.Resume(id); err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	return connect.NewResponse(&pinixv2.ResumeScheduleResponse{}), nil
+}
+
+func (h *HubService) RunSchedule(ctx context.Context, req *connect.Request[pinixv2.RunScheduleRequest]) (*connect.Response[pinixv2.RunScheduleResponse], error) {
+	sched, err := h.requireScheduler()
+	if err != nil {
+		return nil, err
+	}
+	id := strings.TrimSpace(req.Msg.GetId())
+	if id == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("id is required"))
+	}
+	if err := sched.RunNow(id); err != nil {
+		return nil, connect.NewError(connect.CodeNotFound, err)
+	}
+	return connect.NewResponse(&pinixv2.RunScheduleResponse{}), nil
+}
+
+func (h *HubService) GetScheduleHistory(ctx context.Context, req *connect.Request[pinixv2.GetScheduleHistoryRequest]) (*connect.Response[pinixv2.GetScheduleHistoryResponse], error) {
+	sched, err := h.requireScheduler()
+	if err != nil {
+		return nil, err
+	}
+	id := strings.TrimSpace(req.Msg.GetId())
+	if id == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("id is required"))
+	}
+	executions := sched.History(id)
+	pbExecs := make([]*pinixv2.ScheduleExecution, 0, len(executions))
+	for _, e := range executions {
+		pbExecs = append(pbExecs, scheduleExecToProto(e))
+	}
+	return connect.NewResponse(&pinixv2.GetScheduleHistoryResponse{
+		Executions: pbExecs,
+	}), nil
+}
+
+// --- Proto conversion helpers ---
+
+func scheduleConfigToProto(sc ScheduleConfig) *pinixv2.ScheduleRule {
+	return &pinixv2.ScheduleRule{
+		Id:          sc.ID,
+		Clip:        sc.Clip,
+		Command:     sc.Command,
+		Cron:        sc.Cron,
+		Input:       sc.Input,
+		Description: sc.Description,
+		Enabled:     sc.Enabled,
+	}
+}
+
+func scheduleStatusToProto(s ScheduleStatus) *pinixv2.ScheduleStatus {
+	ps := &pinixv2.ScheduleStatus{
+		Rule: scheduleConfigToProto(s.Config),
+	}
+	if s.NextRun != nil {
+		ps.NextRun = s.NextRun.Format(time.RFC3339)
+	}
+	if s.LastRun != nil {
+		ps.LastRun = scheduleExecToProto(*s.LastRun)
+	}
+	return ps
+}
+
+func scheduleExecToProto(e ScheduleExecution) *pinixv2.ScheduleExecution {
+	return &pinixv2.ScheduleExecution{
+		ScheduleId: e.ScheduleID,
+		StartedAt:  e.StartedAt.Format(time.RFC3339),
+		FinishedAt: e.FinishedAt.Format(time.RFC3339),
+		DurationMs: e.DurationMs,
+		Success:    e.Success,
+		Output:     e.Output,
+		Error:      e.Error,
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -14,11 +14,12 @@ import (
 )
 
 type Daemon struct {
-	registry *Registry
-	process  *ProcessManager
-	provider *ProviderManager
-	runtime  *RuntimeManager
-	handler  *Handler
+	registry  *Registry
+	process   *ProcessManager
+	provider  *ProviderManager
+	runtime   *RuntimeManager
+	handler   *Handler
+	scheduler *Scheduler
 
 	mu         sync.Mutex
 	httpServer *http.Server
@@ -60,6 +61,16 @@ func NewHubDaemon(registry *Registry) (*Daemon, error) {
 
 func (d *Daemon) hasLocalRuntime() bool {
 	return d != nil && d.process != nil
+}
+
+// SetScheduler attaches a scheduler to this daemon. Must be called before ServeHTTP or ConnectHub.
+func (d *Daemon) SetScheduler(s *Scheduler) {
+	d.scheduler = s
+}
+
+// GetScheduler returns the attached scheduler, or nil.
+func (d *Daemon) GetScheduler() *Scheduler {
+	return d.scheduler
 }
 
 func (d *Daemon) GetManifest(ctx context.Context, name string) (*ManifestCache, error) {
@@ -125,6 +136,9 @@ func (d *Daemon) Close() error {
 	d.mu.Unlock()
 
 	var errs []error
+	if d.scheduler != nil {
+		d.scheduler.Stop()
+	}
 	if httpServer != nil {
 		if err := httpServer.Close(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errs = append(errs, err)

--- a/internal/daemon/registry.go
+++ b/internal/daemon/registry.go
@@ -50,9 +50,21 @@ type ManifestCache struct {
 	Entities       map[string]json.RawMessage `json:"entities,omitempty"`
 }
 
+// ScheduleConfig holds a user-created scheduled task stored in config.json.
+type ScheduleConfig struct {
+	ID          string `json:"id"`
+	Clip        string `json:"clip"`
+	Command     string `json:"command"`
+	Cron        string `json:"cron"`
+	Input       string `json:"input,omitempty"`
+	Description string `json:"description,omitempty"`
+	Enabled     bool   `json:"enabled"`
+}
+
 type Config struct {
-	SuperToken string                `json:"super_token,omitempty"`
-	Clips      map[string]ClipConfig `json:"clips"`
+	SuperToken string                    `json:"super_token,omitempty"`
+	Clips      map[string]ClipConfig     `json:"clips"`
+	Schedules  map[string]ScheduleConfig `json:"schedules,omitempty"`
 }
 
 type Registry struct {
@@ -176,6 +188,63 @@ func (r *Registry) RemoveClip(name string) (ClipConfig, bool, error) {
 	return removed, ok, err
 }
 
+// --- Schedule CRUD ---
+
+func (r *Registry) ListSchedules() ([]ScheduleConfig, error) {
+	var schedules []ScheduleConfig
+	err := r.withConfig(false, func(cfg *Config) error {
+		schedules = make([]ScheduleConfig, 0, len(cfg.Schedules))
+		for _, s := range cfg.Schedules {
+			schedules = append(schedules, s)
+		}
+		sort.Slice(schedules, func(i, j int) bool {
+			return schedules[i].ID < schedules[j].ID
+		})
+		return nil
+	})
+	return schedules, err
+}
+
+func (r *Registry) GetSchedule(id string) (ScheduleConfig, bool, error) {
+	var (
+		schedule ScheduleConfig
+		ok       bool
+	)
+	err := r.withConfig(false, func(cfg *Config) error {
+		schedule, ok = cfg.Schedules[id]
+		return nil
+	})
+	return schedule, ok, err
+}
+
+func (r *Registry) PutSchedule(schedule ScheduleConfig) error {
+	if strings.TrimSpace(schedule.ID) == "" {
+		return fmt.Errorf("schedule id is required")
+	}
+	return r.withConfig(true, func(cfg *Config) error {
+		if cfg.Schedules == nil {
+			cfg.Schedules = make(map[string]ScheduleConfig)
+		}
+		cfg.Schedules[schedule.ID] = schedule
+		return nil
+	})
+}
+
+func (r *Registry) RemoveSchedule(id string) (ScheduleConfig, bool, error) {
+	var (
+		removed ScheduleConfig
+		ok      bool
+	)
+	err := r.withConfig(true, func(cfg *Config) error {
+		removed, ok = cfg.Schedules[id]
+		if ok {
+			delete(cfg.Schedules, id)
+		}
+		return nil
+	})
+	return removed, ok, err
+}
+
 func (r *Registry) withConfig(exclusive bool, fn func(cfg *Config) error) error {
 	if err := r.ensureBaseDir(); err != nil {
 		return err
@@ -238,12 +307,19 @@ func (r *Registry) loadLocked() (*Config, error) {
 	if cfg.Clips == nil {
 		cfg.Clips = make(map[string]ClipConfig)
 	}
+	if cfg.Schedules == nil {
+		cfg.Schedules = make(map[string]ScheduleConfig)
+	}
 	return &cfg, nil
 }
 
 func (r *Registry) saveLocked(cfg *Config) error {
 	if cfg.Clips == nil {
 		cfg.Clips = make(map[string]ClipConfig)
+	}
+	// Omit empty schedules map from JSON output
+	if len(cfg.Schedules) == 0 {
+		cfg.Schedules = nil
 	}
 
 	data, err := json.MarshalIndent(cfg, "", "  ")

--- a/internal/daemon/scheduler.go
+++ b/internal/daemon/scheduler.go
@@ -1,0 +1,367 @@
+// Role:    Cron-based scheduler that triggers Clip invokes on user-defined schedules
+// Depends: context, encoding/json, fmt, log/slog, sync, time, robfig/cron, internal/client
+// Exports: Scheduler, NewScheduler, ScheduleExecution
+
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/epiral/pinix/internal/client"
+	"github.com/robfig/cron/v3"
+)
+
+const (
+	// maxHistoryPerSchedule is the number of recent executions kept per schedule.
+	maxHistoryPerSchedule = 20
+
+	// scheduleInvokeTimeout is the max duration for a scheduled invoke.
+	scheduleInvokeTimeout = 5 * time.Minute
+)
+
+// ScheduleExecution records a single execution of a scheduled task.
+type ScheduleExecution struct {
+	ScheduleID string          `json:"schedule_id"`
+	StartedAt  time.Time       `json:"started_at"`
+	FinishedAt time.Time       `json:"finished_at"`
+	DurationMs int64           `json:"duration_ms"`
+	Success    bool            `json:"success"`
+	Output     json.RawMessage `json:"output,omitempty"`
+	Error      string          `json:"error,omitempty"`
+}
+
+// scheduleEntry tracks a registered cron entry.
+type scheduleEntry struct {
+	config  ScheduleConfig
+	entryID cron.EntryID
+}
+
+// Scheduler manages cron-triggered Clip invokes.
+type Scheduler struct {
+	registry *Registry
+	hubURL   string
+	hubToken string
+
+	cron *cron.Cron
+
+	mu      sync.RWMutex
+	entries map[string]*scheduleEntry // schedule ID -> entry
+
+	historyMu sync.RWMutex
+	history   map[string][]ScheduleExecution // schedule ID -> recent executions (ring buffer)
+
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// NewScheduler creates a new scheduler. Call Start() to begin scheduling.
+func NewScheduler(registry *Registry, hubURL string) *Scheduler {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Scheduler{
+		registry: registry,
+		hubURL:   hubURL,
+		cron:     cron.New(cron.WithSeconds()),
+		entries:  make(map[string]*scheduleEntry),
+		history:  make(map[string][]ScheduleExecution),
+		ctx:      ctx,
+		cancel:   cancel,
+	}
+}
+
+// SetHubToken sets the hub auth token for scheduled invokes.
+func (s *Scheduler) SetHubToken(token string) {
+	s.mu.Lock()
+	s.hubToken = token
+	s.mu.Unlock()
+}
+
+// Start loads schedules from the registry and starts the cron engine.
+func (s *Scheduler) Start() error {
+	schedules, err := s.registry.ListSchedules()
+	if err != nil {
+		return fmt.Errorf("load schedules: %w", err)
+	}
+
+	for _, sc := range schedules {
+		if !sc.Enabled {
+			continue
+		}
+		if err := s.registerEntry(sc); err != nil {
+			slog.Warn("scheduler: skip invalid schedule",
+				"id", sc.ID, "cron", sc.Cron, "error", err,
+			)
+		}
+	}
+
+	s.cron.Start()
+	slog.Info("scheduler: started", "schedules", len(schedules))
+	return nil
+}
+
+// Stop gracefully shuts down the scheduler.
+func (s *Scheduler) Stop() {
+	s.cancel()
+	ctx := s.cron.Stop()
+	<-ctx.Done()
+	slog.Info("scheduler: stopped")
+}
+
+// Add creates a new schedule, persists it, and registers it with the cron engine.
+func (s *Scheduler) Add(sc ScheduleConfig) error {
+	// Validate cron expression
+	parser := cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	if _, err := parser.Parse(sc.Cron); err != nil {
+		return fmt.Errorf("invalid cron expression %q: %w", sc.Cron, err)
+	}
+
+	sc.Enabled = true
+	if err := s.registry.PutSchedule(sc); err != nil {
+		return fmt.Errorf("save schedule: %w", err)
+	}
+
+	if err := s.registerEntry(sc); err != nil {
+		return fmt.Errorf("register schedule: %w", err)
+	}
+
+	slog.Info("scheduler: added", "id", sc.ID, "clip", sc.Clip, "command", sc.Command, "cron", sc.Cron)
+	return nil
+}
+
+// Remove deletes a schedule from persistence and the cron engine.
+func (s *Scheduler) Remove(id string) error {
+	s.mu.Lock()
+	entry, ok := s.entries[id]
+	if ok {
+		s.cron.Remove(entry.entryID)
+		delete(s.entries, id)
+	}
+	s.mu.Unlock()
+
+	_, found, err := s.registry.RemoveSchedule(id)
+	if err != nil {
+		return fmt.Errorf("remove schedule: %w", err)
+	}
+	if !found && !ok {
+		return fmt.Errorf("schedule %q not found", id)
+	}
+
+	s.historyMu.Lock()
+	delete(s.history, id)
+	s.historyMu.Unlock()
+
+	slog.Info("scheduler: removed", "id", id)
+	return nil
+}
+
+// Pause disables a schedule without deleting it.
+func (s *Scheduler) Pause(id string) error {
+	s.mu.Lock()
+	entry, ok := s.entries[id]
+	if ok {
+		s.cron.Remove(entry.entryID)
+		delete(s.entries, id)
+	}
+	s.mu.Unlock()
+
+	sc, found, err := s.registry.GetSchedule(id)
+	if err != nil {
+		return fmt.Errorf("get schedule: %w", err)
+	}
+	if !found {
+		return fmt.Errorf("schedule %q not found", id)
+	}
+
+	sc.Enabled = false
+	if err := s.registry.PutSchedule(sc); err != nil {
+		return fmt.Errorf("save schedule: %w", err)
+	}
+
+	slog.Info("scheduler: paused", "id", id)
+	return nil
+}
+
+// Resume re-enables a paused schedule.
+func (s *Scheduler) Resume(id string) error {
+	sc, found, err := s.registry.GetSchedule(id)
+	if err != nil {
+		return fmt.Errorf("get schedule: %w", err)
+	}
+	if !found {
+		return fmt.Errorf("schedule %q not found", id)
+	}
+
+	sc.Enabled = true
+	if err := s.registry.PutSchedule(sc); err != nil {
+		return fmt.Errorf("save schedule: %w", err)
+	}
+
+	if err := s.registerEntry(sc); err != nil {
+		return fmt.Errorf("register schedule: %w", err)
+	}
+
+	slog.Info("scheduler: resumed", "id", id)
+	return nil
+}
+
+// RunNow triggers a schedule immediately, ignoring cron timing.
+func (s *Scheduler) RunNow(id string) error {
+	sc, found, err := s.registry.GetSchedule(id)
+	if err != nil {
+		return fmt.Errorf("get schedule: %w", err)
+	}
+	if !found {
+		return fmt.Errorf("schedule %q not found", id)
+	}
+
+	go s.executeSchedule(sc)
+	return nil
+}
+
+// List returns all schedules with their next run time.
+func (s *Scheduler) List() ([]ScheduleStatus, error) {
+	schedules, err := s.registry.ListSchedules()
+	if err != nil {
+		return nil, err
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make([]ScheduleStatus, 0, len(schedules))
+	for _, sc := range schedules {
+		status := ScheduleStatus{
+			Config: sc,
+		}
+		if entry, ok := s.entries[sc.ID]; ok {
+			cronEntry := s.cron.Entry(entry.entryID)
+			if !cronEntry.Next.IsZero() {
+				status.NextRun = &cronEntry.Next
+			}
+		}
+		// Attach last execution
+		s.historyMu.RLock()
+		if hist, ok := s.history[sc.ID]; ok && len(hist) > 0 {
+			last := hist[len(hist)-1]
+			status.LastRun = &last
+		}
+		s.historyMu.RUnlock()
+
+		result = append(result, status)
+	}
+	return result, nil
+}
+
+// History returns recent executions for a schedule.
+func (s *Scheduler) History(id string) []ScheduleExecution {
+	s.historyMu.RLock()
+	defer s.historyMu.RUnlock()
+
+	hist, ok := s.history[id]
+	if !ok {
+		return nil
+	}
+	// Return a copy
+	out := make([]ScheduleExecution, len(hist))
+	copy(out, hist)
+	return out
+}
+
+// ScheduleStatus is a schedule config with runtime status.
+type ScheduleStatus struct {
+	Config  ScheduleConfig     `json:"config"`
+	NextRun *time.Time         `json:"next_run,omitempty"`
+	LastRun *ScheduleExecution `json:"last_run,omitempty"`
+}
+
+// registerEntry adds a schedule to the cron engine.
+func (s *Scheduler) registerEntry(sc ScheduleConfig) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Remove existing entry if re-registering
+	if existing, ok := s.entries[sc.ID]; ok {
+		s.cron.Remove(existing.entryID)
+		delete(s.entries, sc.ID)
+	}
+
+	entryID, err := s.cron.AddFunc(sc.Cron, func() {
+		s.executeSchedule(sc)
+	})
+	if err != nil {
+		return err
+	}
+
+	s.entries[sc.ID] = &scheduleEntry{
+		config:  sc,
+		entryID: entryID,
+	}
+	return nil
+}
+
+// executeSchedule runs a single scheduled invoke and records the result.
+func (s *Scheduler) executeSchedule(sc ScheduleConfig) {
+	start := time.Now()
+
+	slog.Info("scheduler: executing",
+		"id", sc.ID, "clip", sc.Clip, "command", sc.Command,
+	)
+
+	ctx, cancel := context.WithTimeout(s.ctx, scheduleInvokeTimeout)
+	defer cancel()
+
+	cli, err := client.New(s.hubURL)
+	if err != nil {
+		s.recordExecution(sc.ID, start, nil, fmt.Errorf("create client: %w", err))
+		return
+	}
+
+	var input json.RawMessage
+	if sc.Input != "" {
+		input = json.RawMessage(sc.Input)
+	}
+
+	s.mu.RLock()
+	token := s.hubToken
+	s.mu.RUnlock()
+
+	output, err := cli.Invoke(ctx, sc.Clip, sc.Command, input, "", token)
+	s.recordExecution(sc.ID, start, output, err)
+}
+
+// recordExecution appends an execution result to the history ring buffer.
+func (s *Scheduler) recordExecution(id string, startedAt time.Time, output json.RawMessage, invokeErr error) {
+	finished := time.Now()
+	exec := ScheduleExecution{
+		ScheduleID: id,
+		StartedAt:  startedAt,
+		FinishedAt: finished,
+		DurationMs: finished.Sub(startedAt).Milliseconds(),
+		Success:    invokeErr == nil,
+		Output:     output,
+	}
+	if invokeErr != nil {
+		exec.Error = invokeErr.Error()
+		slog.Error("scheduler: execution failed",
+			"id", id, "duration_ms", exec.DurationMs, "error", invokeErr,
+		)
+	} else {
+		slog.Info("scheduler: execution succeeded",
+			"id", id, "duration_ms", exec.DurationMs,
+		)
+	}
+
+	s.historyMu.Lock()
+	defer s.historyMu.Unlock()
+
+	hist := s.history[id]
+	hist = append(hist, exec)
+	if len(hist) > maxHistoryPerSchedule {
+		hist = hist[len(hist)-maxHistoryPerSchedule:]
+	}
+	s.history[id] = hist
+}

--- a/proto/pinix/v2/hub.proto
+++ b/proto/pinix/v2/hub.proto
@@ -36,6 +36,15 @@ service HubService {
   rpc GetBindings(GetBindingsRequest) returns (GetBindingsResponse);
   rpc SetBinding(SetBindingRequest) returns (SetBindingResponse);
   rpc RemoveBinding(RemoveBindingRequest) returns (RemoveBindingResponse);
+
+  // Schedule management
+  rpc ListSchedules(ListSchedulesRequest) returns (ListSchedulesResponse);
+  rpc AddSchedule(AddScheduleRequest) returns (AddScheduleResponse);
+  rpc RemoveSchedule(RemoveScheduleRequest) returns (RemoveScheduleResponse);
+  rpc PauseSchedule(PauseScheduleRequest) returns (PauseScheduleResponse);
+  rpc ResumeSchedule(ResumeScheduleRequest) returns (ResumeScheduleResponse);
+  rpc RunSchedule(RunScheduleRequest) returns (RunScheduleResponse);
+  rpc GetScheduleHistory(GetScheduleHistoryRequest) returns (GetScheduleHistoryResponse);
 }
 
 message HubError {
@@ -432,4 +441,85 @@ message DataResult {
   repeated DataEntry entries = 4;
   DataStat stat = 5;
   HubError error = 6;
+}
+
+// ============================================================
+//  Scheduled Tasks
+// ============================================================
+
+message ScheduleRule {
+  string id = 1;
+  string clip = 2;
+  string command = 3;
+  string cron = 4;
+  string input = 5;          // JSON string
+  string description = 6;
+  bool enabled = 7;
+}
+
+message ScheduleStatus {
+  ScheduleRule rule = 1;
+  string next_run = 2;       // ISO 8601
+  ScheduleExecution last_run = 3;
+}
+
+message ScheduleExecution {
+  string schedule_id = 1;
+  string started_at = 2;     // ISO 8601
+  string finished_at = 3;    // ISO 8601
+  int64 duration_ms = 4;
+  bool success = 5;
+  bytes output = 6;
+  string error = 7;
+}
+
+message ListSchedulesRequest {}
+
+message ListSchedulesResponse {
+  repeated ScheduleStatus schedules = 1;
+}
+
+message AddScheduleRequest {
+  string id = 1;
+  string clip = 2;
+  string command = 3;
+  string cron = 4;
+  string input = 5;
+  string description = 6;
+}
+
+message AddScheduleResponse {
+  ScheduleRule rule = 1;
+}
+
+message RemoveScheduleRequest {
+  string id = 1;
+}
+
+message RemoveScheduleResponse {}
+
+message PauseScheduleRequest {
+  string id = 1;
+}
+
+message PauseScheduleResponse {}
+
+message ResumeScheduleRequest {
+  string id = 1;
+}
+
+message ResumeScheduleResponse {}
+
+message RunScheduleRequest {
+  string id = 1;
+}
+
+message RunScheduleResponse {}
+
+message GetScheduleHistoryRequest {
+  string id = 1;
+}
+
+message GetScheduleHistoryResponse {
+  repeated ScheduleExecution executions = 1;
 }


### PR DESCRIPTION
## Summary

Add a cron-based scheduler to pinixd for timed Clip invocations.

Closes #136

## Changes

### New files
- `internal/daemon/scheduler.go` — Cron engine (robfig/cron v3): register/execute/pause/resume/history
- `cmd/pinix/schedule.go` — CLI: `pinix schedule list|add|remove|pause|resume|run|history`

### Modified files
- `proto/pinix/v2/hub.proto` — 7 schedule RPCs + message types
- `internal/daemon/connect.go` — RPC handlers
- `internal/daemon/registry.go` — `ScheduleConfig` type + CRUD on config.json
- `internal/client/client.go` — Schedule client methods
- `internal/daemon/daemon.go` — Scheduler field + lifecycle
- `cmd/pinixd/main.go` — Wire scheduler in Mode 2 (--hub) and Mode 3 (full)
- `cmd/pinix/main.go` — Register schedule subcommand

## Design

- **Truth source is local pinixd** — schedules stored in `~/.pinix/config.json`
- **Standard invoke path** — scheduler triggers via Hub invoke, Hub is unaware
- **Mode 3 (full)**: scheduler on hubDaemon (serves RPCs)
- **Mode 2 (--hub)**: scheduler on runtimeDaemon (RPC mgmt deferred to P2)
- **Mode 1 (hub-only)**: no scheduler
- **History**: in-memory ring buffer, 20 entries per schedule

## Usage

```bash
pinix schedule add morning-digest lark-im search --cron "0 9 * * *" --input '{"query":"unread"}'
pinix schedule list
pinix schedule pause morning-digest
pinix schedule resume morning-digest
pinix schedule run morning-digest      # manual trigger
pinix schedule history morning-digest
pinix schedule remove morning-digest
```

## Verification

- `go build ./...` ✅
- `go test ./...` ✅
- `go vet` — only pre-existing warning in daemon.go:347