### PR TITLE
feat(scheduler): clip-declared schedules + ProviderStream sync (P1+P2)

### DIFF
--- a/cmd/pinix/daemon.go
+++ b/cmd/pinix/daemon.go
@@ -344,7 +344,7 @@ func startBrowserDaemon(localHubURL, hubToken, cloudHubURL string) *exec.Cmd {
 	cmd := exec.Command(bin, args...)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
-	cmd.Env = append(os.Environ()) // inherit DISPLAY from ensureDisplay()
+	cmd.Env = os.Environ() // inherit DISPLAY from ensureDisplay()
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	if err := cmd.Start(); err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	pinixv2 "github.com/epiral/pinix/gen/go/pinix/v2"
 	"github.com/epiral/pinix/internal/agent"
 )
 
@@ -206,9 +207,29 @@ func (d *Daemon) hasLocalRuntime() bool {
 	return d != nil && d.process != nil
 }
 
-// SetScheduler attaches a scheduler to this daemon. Must be called before ServeHTTP or ConnectHub.
+// SetScheduler attaches a scheduler to this daemon and wires up clip-declared schedule registration.
 func (d *Daemon) SetScheduler(s *Scheduler) {
 	d.scheduler = s
+
+	// When a provider registers a clip with schedule declarations, auto-register them.
+	if d.provider != nil {
+		d.provider.SetOnClipAdded(func(alias string, registration *pinixv2.ClipRegistration) {
+			if s == nil || registration == nil || len(registration.GetSchedules()) == 0 {
+				return
+			}
+			decls := make([]ManifestScheduleDecl, 0, len(registration.GetSchedules()))
+			for _, sd := range registration.GetSchedules() {
+				decls = append(decls, ManifestScheduleDecl{
+					Command:     sd.GetCommand(),
+					Cron:        sd.GetCron(),
+					Input:       sd.GetInput(),
+					Description: sd.GetDescription(),
+				})
+			}
+			manifest := &ManifestCache{Schedules: decls}
+			s.RegisterClipSchedules(alias, manifest)
+		})
+	}
 }
 
 // GetScheduler returns the attached scheduler, or nil.

--- a/internal/daemon/manifest.go
+++ b/internal/daemon/manifest.go
@@ -24,15 +24,16 @@ type packageJSON struct {
 
 // ClipJSON represents the clip.json package identity file.
 type ClipJSON struct {
-	Name        string `json:"name"`
-	Version     string `json:"version"`
-	Description string `json:"description"`
-	Runtime     string `json:"runtime"`
-	Main        string `json:"main"`
-	Web         string `json:"web"`
-	Author      string `json:"author"`
-	License     string `json:"license"`
-	Repository  string `json:"repository"`
+	Name        string                 `json:"name"`
+	Version     string                 `json:"version"`
+	Description string                 `json:"description"`
+	Runtime     string                 `json:"runtime"`
+	Main        string                 `json:"main"`
+	Web         string                 `json:"web"`
+	Author      string                 `json:"author"`
+	License     string                 `json:"license"`
+	Repository  string                 `json:"repository"`
+	Schedules   []ManifestScheduleDecl `json:"schedules,omitempty"`
 }
 
 type projectMetadata struct {
@@ -45,6 +46,7 @@ type projectMetadata struct {
 	Dependencies map[string]DependencySpec
 	Patterns     []string
 	Commands     []CommandInfo
+	Schedules    []ManifestScheduleDecl
 }
 
 type manifestDependencies map[string]DependencySpec
@@ -85,6 +87,9 @@ func enrichManifestForClip(clip ClipConfig, manifest *ManifestCache) *ManifestCa
 		}
 		if len(merged.CommandDetails) == 0 {
 			merged.CommandDetails = normalizeCommandDetails(meta.Commands)
+		}
+		if len(merged.Schedules) == 0 {
+			merged.Schedules = normalizeScheduleDecls(meta.Schedules)
 		}
 	}
 
@@ -166,6 +171,7 @@ func readClipJSONMetadata(workdir string) (*projectMetadata, error) {
 		Description: strings.TrimSpace(clip.Description),
 		Main:        strings.TrimSpace(clip.Main),
 		Web:         strings.TrimSpace(clip.Web),
+		Schedules:   normalizeScheduleDecls(clip.Schedules),
 	}
 	return meta, nil
 }
@@ -200,6 +206,9 @@ func mergeProjectMetadata(target, source *projectMetadata) {
 	}
 	if len(target.Commands) == 0 {
 		target.Commands = normalizeCommandDetails(source.Commands)
+	}
+	if len(target.Schedules) == 0 {
+		target.Schedules = normalizeScheduleDecls(source.Schedules)
 	}
 }
 
@@ -362,6 +371,7 @@ func cloneManifest(manifest *ManifestCache) *ManifestCache {
 		Dependencies:   cloneDependencySpecs(manifest.Dependencies),
 		Patterns:       append([]string(nil), manifest.Patterns...),
 		Entities:       cloneEntities(manifest.Entities),
+		Schedules:      append([]ManifestScheduleDecl(nil), manifest.Schedules...),
 	}
 	return cloned
 }
@@ -396,6 +406,7 @@ func finalizeManifestCache(manifest *ManifestCache) *ManifestCache {
 	if len(manifest.Commands) == 0 {
 		manifest.Commands = normalizeStrings(manifest.Commands)
 	}
+	manifest.Schedules = normalizeScheduleDecls(manifest.Schedules)
 	return manifest
 }
 
@@ -510,4 +521,32 @@ func derivePackageName(clip ClipConfig) string {
 		return strings.TrimSpace(clip.Manifest.Package)
 	}
 	return strings.TrimSpace(clip.Name)
+}
+
+// normalizeScheduleDecls deduplicates and trims schedule declarations.
+func normalizeScheduleDecls(schedules []ManifestScheduleDecl) []ManifestScheduleDecl {
+	if len(schedules) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(schedules))
+	cleaned := make([]ManifestScheduleDecl, 0, len(schedules))
+	for _, s := range schedules {
+		command := strings.TrimSpace(s.Command)
+		cron := strings.TrimSpace(s.Cron)
+		if command == "" || cron == "" {
+			continue
+		}
+		key := command + "|" + cron
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		cleaned = append(cleaned, ManifestScheduleDecl{
+			Command:     command,
+			Cron:        cron,
+			Input:       strings.TrimSpace(s.Input),
+			Description: strings.TrimSpace(s.Description),
+		})
+	}
+	return cleaned
 }

--- a/internal/daemon/process.go
+++ b/internal/daemon/process.go
@@ -1407,6 +1407,7 @@ func registeredManifestForClip(clip ClipConfig, manifest *ipc.Manifest) (*Manife
 		Dependencies:   ipcDependencySpecsToInternal(manifest.Dependencies),
 		Patterns:       normalizeStrings(manifest.Patterns),
 		Entities:       manifest.Entities,
+		Schedules:      ipcSchedulesToInternal(manifest.Schedules),
 	}
 	registered.Commands = commandNames(registered.CommandDetails)
 	registered = enrichManifestForClip(clip, registered)
@@ -1414,6 +1415,27 @@ func registeredManifestForClip(clip ClipConfig, manifest *ipc.Manifest) (*Manife
 		return nil, fmt.Errorf("register alias is required")
 	}
 	return registered, nil
+}
+
+func ipcSchedulesToInternal(schedules []ipc.ManifestSchedule) []ManifestScheduleDecl {
+	if len(schedules) == 0 {
+		return nil
+	}
+	result := make([]ManifestScheduleDecl, 0, len(schedules))
+	for _, s := range schedules {
+		command := strings.TrimSpace(s.Command)
+		cron := strings.TrimSpace(s.Cron)
+		if command == "" || cron == "" {
+			continue
+		}
+		result = append(result, ManifestScheduleDecl{
+			Command:     command,
+			Cron:        cron,
+			Input:       strings.TrimSpace(s.Input),
+			Description: strings.TrimSpace(s.Description),
+		})
+	}
+	return result
 }
 
 func ipcDependencySpecsToInternal(values map[string]ipc.DependencySpec) map[string]DependencySpec {

--- a/internal/daemon/provider.go
+++ b/internal/daemon/provider.go
@@ -38,6 +38,8 @@ type ProviderManager struct {
 	clips     map[string]*providerClipRef
 	reserved  map[string]aliasReservation
 	nextID    atomic.Uint64
+
+	onClipAdded func(alias string, registration *pinixv2.ClipRegistration)
 }
 
 type aliasReservation struct {
@@ -130,6 +132,13 @@ func NewProviderManager(registry *Registry) *ProviderManager {
 		clips:     make(map[string]*providerClipRef),
 		reserved:  make(map[string]aliasReservation),
 	}
+}
+
+// SetOnClipAdded sets a callback fired when a clip is registered via ProviderStream.
+func (m *ProviderManager) SetOnClipAdded(fn func(alias string, registration *pinixv2.ClipRegistration)) {
+	m.mu.Lock()
+	m.onClipAdded = fn
+	m.mu.Unlock()
 }
 
 func (m *ProviderManager) ReserveAlias(requestedAlias, source, owner string) (string, error) {
@@ -634,6 +643,12 @@ func (m *ProviderManager) addClipToSession(session *providerSession, registratio
 	session.clips[alias] = clip
 	m.clips[alias] = &providerClipRef{session: session, clip: clip}
 	delete(m.reserved, alias)
+
+	// Notify listener (e.g., scheduler for clip-declared schedules)
+	if fn := m.onClipAdded; fn != nil {
+		fn(alias, clip.registration)
+	}
+
 	return providerClipToClipInfo(session.name, clip), nil
 }
 
@@ -1083,6 +1098,7 @@ func sanitizeProviderClip(registration *pinixv2.ClipRegistration) (*providerClip
 		TokenProtected: registration.GetTokenProtected(),
 		Patterns:       normalizeStrings(registration.GetPatterns()),
 		Entities:       registration.GetEntities(),
+		Schedules:      registration.GetSchedules(),
 	}
 	return &providerClip{registration: sanitized}, nil
 }

--- a/internal/daemon/registry.go
+++ b/internal/daemon/registry.go
@@ -36,6 +36,14 @@ type DependencySpec struct {
 	Version string `json:"version,omitempty"`
 }
 
+// ManifestScheduleDecl is a Clip-declared scheduled command (from clip.json or IPC register).
+type ManifestScheduleDecl struct {
+	Command     string `json:"command"`
+	Cron        string `json:"cron"`
+	Input       string `json:"input,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
 type ManifestCache struct {
 	Name           string                     `json:"name"`
 	Package        string                     `json:"package,omitempty"`
@@ -48,6 +56,7 @@ type ManifestCache struct {
 	Dependencies   manifestDependencies       `json:"dependencies,omitempty"`
 	Patterns       []string                   `json:"patterns,omitempty"`
 	Entities       map[string]json.RawMessage `json:"entities,omitempty"`
+	Schedules      []ManifestScheduleDecl     `json:"schedules,omitempty"`
 }
 
 // ScheduleConfig holds a user-created scheduled task stored in config.json.

--- a/internal/daemon/runtime_hub.go
+++ b/internal/daemon/runtime_hub.go
@@ -834,5 +834,22 @@ func localClipToRegistration(clip ClipConfig) *pinixv2.ClipRegistration {
 		Dependencies: dependencySlots(manifest.Dependencies),
 		Patterns:     append([]string(nil), manifest.Patterns...),
 		Entities:     entitiesToProto(manifest.Entities),
+		Schedules:    scheduleDeclsToProto(manifest.Schedules),
 	}
+}
+
+func scheduleDeclsToProto(decls []ManifestScheduleDecl) []*pinixv2.ScheduleDeclaration {
+	if len(decls) == 0 {
+		return nil
+	}
+	result := make([]*pinixv2.ScheduleDeclaration, 0, len(decls))
+	for _, d := range decls {
+		result = append(result, &pinixv2.ScheduleDeclaration{
+			Command:     d.Command,
+			Cron:        d.Cron,
+			Input:       d.Input,
+			Description: d.Description,
+		})
+	}
+	return result
 }

--- a/internal/daemon/scheduler.go
+++ b/internal/daemon/scheduler.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -80,8 +81,9 @@ func (s *Scheduler) SetHubToken(token string) {
 	s.mu.Unlock()
 }
 
-// Start loads schedules from the registry and starts the cron engine.
+// Start loads schedules from the registry, registers clip-declared schedules, and starts the cron engine.
 func (s *Scheduler) Start() error {
+	// Load user-created schedules
 	schedules, err := s.registry.ListSchedules()
 	if err != nil {
 		return fmt.Errorf("load schedules: %w", err)
@@ -98,9 +100,69 @@ func (s *Scheduler) Start() error {
 		}
 	}
 
+	// Load clip-declared schedules from manifests
+	clips, err := s.registry.ListClips()
+	if err != nil {
+		slog.Warn("scheduler: failed to load clips for manifest schedules", "error", err)
+	} else {
+		for _, clip := range clips {
+			s.registerClipSchedules(clip.Name, clip.Manifest)
+		}
+	}
+
 	s.cron.Start()
 	slog.Info("scheduler: started", "schedules", len(schedules))
 	return nil
+}
+
+// RegisterClipSchedules registers (or re-registers) all schedule declarations
+// from a Clip's manifest. Called when a Clip is installed or its manifest updates.
+func (s *Scheduler) RegisterClipSchedules(clipName string, manifest *ManifestCache) {
+	s.registerClipSchedules(clipName, manifest)
+}
+
+// UnregisterClipSchedules removes all clip-declared schedules for the given clip.
+func (s *Scheduler) UnregisterClipSchedules(clipName string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	prefix := "clip:" + clipName + ":"
+	for id, entry := range s.entries {
+		if strings.HasPrefix(id, prefix) {
+			s.cron.Remove(entry.entryID)
+			delete(s.entries, id)
+			slog.Info("scheduler: unregistered clip schedule", "id", id)
+		}
+	}
+}
+
+func (s *Scheduler) registerClipSchedules(clipName string, manifest *ManifestCache) {
+	if manifest == nil || len(manifest.Schedules) == 0 {
+		return
+	}
+
+	for _, decl := range manifest.Schedules {
+		// Clip-declared schedule IDs are prefixed to avoid collision with user schedules
+		scheduleID := "clip:" + clipName + ":" + decl.Command
+		sc := ScheduleConfig{
+			ID:          scheduleID,
+			Clip:        clipName,
+			Command:     decl.Command,
+			Cron:        decl.Cron,
+			Input:       decl.Input,
+			Description: decl.Description,
+			Enabled:     true,
+		}
+		if err := s.registerEntry(sc); err != nil {
+			slog.Warn("scheduler: skip invalid clip schedule",
+				"clip", clipName, "command", decl.Command, "cron", decl.Cron, "error", err,
+			)
+		} else {
+			slog.Info("scheduler: registered clip schedule",
+				"id", scheduleID, "clip", clipName, "command", decl.Command, "cron", decl.Cron,
+			)
+		}
+	}
 }
 
 // Stop gracefully shuts down the scheduler.

--- a/internal/ipc/ipc.go
+++ b/internal/ipc/ipc.go
@@ -76,6 +76,15 @@ type Manifest struct {
 	Dependencies Dependencies                   `json:"dependencies,omitempty"`
 	Patterns     []string                       `json:"patterns,omitempty"`
 	Entities     map[string]json.RawMessage     `json:"entities,omitempty"`
+	Schedules    []ManifestSchedule             `json:"schedules,omitempty"`
+}
+
+// ManifestSchedule is a Clip-declared scheduled command.
+type ManifestSchedule struct {
+	Command     string `json:"command"`
+	Cron        string `json:"cron"`
+	Input       string `json:"input,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 type Dependencies map[string]DependencySpec

--- a/proto/pinix/v2/hub.proto
+++ b/proto/pinix/v2/hub.proto
@@ -183,6 +183,15 @@ message ClipRegistration {
   repeated string patterns = 10;
   map<string, string> entities = 11;
   string description = 12;
+  repeated ScheduleDeclaration schedules = 13;
+}
+
+// Clip-declared schedule: a command the Clip wants to run periodically.
+message ScheduleDeclaration {
+  string command = 1;
+  string cron = 2;
+  string input = 3;          // JSON string
+  string description = 4;
 }
 
 message ClipAdded {


### PR DESCRIPTION
## Summary

Add clip-declared (manifest) schedules and ProviderStream schedule sync.

Builds on #136 (P0).

## P1: Clip manifest declarative schedules

Clips can now declare schedules in `clip.json`:
```json
{
  "schedules": [
    { "command": "sync", "cron": "*/5 * * * *", "description": "Periodic sync" },
    { "command": "cleanup", "cron": "0 2 * * *", "input": "{\"days\":30}" }
  ]
}
```

- Added `schedules` field to `ClipJSON`, `projectMetadata`, `ipc.Manifest`, `ManifestCache`
- Full pipeline: clip.json parse -> merge -> clone -> finalize -> persist
- IPC register message can carry schedules from Clip process
- Scheduler auto-registers clip-declared schedules on startup (`clip:<alias>:<command>` IDs)
- Dynamic registration via `onClipAdded` callback when Provider registers clips

## P2: ProviderStream schedule sync

- Added `ScheduleDeclaration` proto message + `schedules` field to `ClipRegistration`
- `localClipToRegistration()` includes schedules when Provider registers with Hub
- `sanitizeProviderClip()` passes through schedule declarations from remote Providers
- Hub-side `onClipAdded` fires scheduler registration for incoming clip schedules

## Verification

- `go build ./...` pass
- `go test ./...` pass