### PR TITLE
fix(scheduler): support standard 5-field cron expressions

### DIFF
--- a/internal/daemon/scheduler.go
+++ b/internal/daemon/scheduler.go
@@ -66,7 +66,7 @@ func NewScheduler(registry *Registry, hubURL string) *Scheduler {
 	return &Scheduler{
 		registry: registry,
 		hubURL:   hubURL,
-		cron:     cron.New(cron.WithSeconds()),
+		cron:     cron.New(cron.WithParser(cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow))),
 		entries:  make(map[string]*scheduleEntry),
 		history:  make(map[string][]ScheduleExecution),
 		ctx:      ctx,


### PR DESCRIPTION
cron.New was using WithSeconds() which requires 6 fields. Standard cron uses 5 fields. Switch to SecondOptional parser to accept both formats.