### PR TITLE
refactor(builtin): unify agent + scheduler as builtin clips

### DIFF
--- a/internal/builtin/agent.go
+++ b/internal/builtin/agent.go
@@ -1,0 +1,53 @@
+// Role:    Builtin "agent" Clip — bridges agent.Handler into the builtin Clip framework
+// Depends: context, encoding/json, internal/agent
+// Exports: NewAgentClip
+
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/epiral/pinix/internal/agent"
+)
+
+// NewAgentClip creates a builtin Clip that wraps an agent.Handler.
+// All commands delegate to handler.HandleInvoke, preserving streaming via onChunk.
+func NewAgentClip(handler *agent.Handler) *Clip {
+	// All agent commands route through HandleInvoke, which does its own switch.
+	// We register each command individually so ListClips/GetManifest shows them.
+	makeHandler := func(command string) CommandHandler {
+		return func(ctx context.Context, input json.RawMessage, onChunk ChunkFunc) (json.RawMessage, error) {
+			return handler.HandleInvoke(ctx, command, input, onChunk)
+		}
+	}
+
+	return &Clip{
+		Name:        "agent",
+		Package:     "@pinix/agent",
+		Version:     "1.0.0",
+		Domain:      "ai",
+		Description: "Built-in AI Agent Runtime",
+		Commands: []CommandDef{
+			{Name: "chat", Description: "Send a message and get a streaming response", Input: `{"type":"object","properties":{"agent_id":{"type":"string"},"topic_id":{"type":"string"},"message":{"type":"string"}},"required":["agent_id","message"]}`, Handler: makeHandler("chat")},
+			{Name: "topic list", Description: "List all topics for an agent", Handler: makeHandler("topic list")},
+			{Name: "topic get", Description: "Get topic details with messages", Handler: makeHandler("topic get")},
+			{Name: "topic create", Description: "Create a new topic", Handler: makeHandler("topic create")},
+			{Name: "topic delete", Description: "Delete a topic", Handler: makeHandler("topic delete")},
+			{Name: "topic rename", Description: "Rename a topic", Handler: makeHandler("topic rename")},
+			{Name: "topic search", Description: "Search across topics", Handler: makeHandler("topic search")},
+			{Name: "run get", Description: "Get run details", Handler: makeHandler("run get")},
+			{Name: "run cancel", Description: "Cancel a running run", Handler: makeHandler("run cancel")},
+			{Name: "agent list", Description: "List all agent configurations", Handler: makeHandler("agent list")},
+			{Name: "agent get", Description: "Get agent details", Handler: makeHandler("agent get")},
+			{Name: "agent create", Description: "Create a new agent", Handler: makeHandler("agent create")},
+			{Name: "agent update", Description: "Update agent configuration", Handler: makeHandler("agent update")},
+			{Name: "agent delete", Description: "Delete an agent", Handler: makeHandler("agent delete")},
+			{Name: "event create", Description: "Create a scheduled event", Handler: makeHandler("event create")},
+			{Name: "event list", Description: "List scheduled events", Handler: makeHandler("event list")},
+			{Name: "event update", Description: "Update a scheduled event", Handler: makeHandler("event update")},
+			{Name: "event cancel", Description: "Cancel a scheduled event", Handler: makeHandler("event cancel")},
+			{Name: "config get", Description: "Get global agent configuration", Handler: makeHandler("config get")},
+		},
+	}
+}

--- a/internal/builtin/builtin.go
+++ b/internal/builtin/builtin.go
@@ -11,8 +11,13 @@ import (
 	"strings"
 )
 
+// ChunkFunc is called to send streaming output chunks.
+type ChunkFunc func(json.RawMessage)
+
 // CommandHandler handles a single command invocation.
-type CommandHandler func(ctx context.Context, input json.RawMessage) (json.RawMessage, error)
+// onChunk may be nil for non-streaming callers; handlers that support streaming
+// should check before calling it.
+type CommandHandler func(ctx context.Context, input json.RawMessage, onChunk ChunkFunc) (json.RawMessage, error)
 
 // CommandDef describes a command exposed by a builtin Clip.
 type CommandDef struct {
@@ -33,11 +38,12 @@ type Clip struct {
 }
 
 // Invoke dispatches a command to the matching handler.
-func (c *Clip) Invoke(ctx context.Context, command string, input json.RawMessage) (json.RawMessage, error) {
+// onChunk may be nil for non-streaming callers.
+func (c *Clip) Invoke(ctx context.Context, command string, input json.RawMessage, onChunk ChunkFunc) (json.RawMessage, error) {
 	command = strings.TrimSpace(command)
 	for _, cmd := range c.Commands {
 		if cmd.Name == command {
-			return cmd.Handler(ctx, input)
+			return cmd.Handler(ctx, input, onChunk)
 		}
 	}
 	return nil, fmt.Errorf("command %q not found on builtin clip %q", command, c.Name)

--- a/internal/builtin/scheduler.go
+++ b/internal/builtin/scheduler.go
@@ -17,14 +17,8 @@ type SchedulerInvoker interface {
 
 // NewSchedulerClip creates a builtin Clip backed by a SchedulerInvoker.
 func NewSchedulerClip(invoker SchedulerInvoker) *Clip {
-	handler := func(ctx context.Context, input json.RawMessage) (json.RawMessage, error) {
-		// This will be overridden per-command below; placeholder.
-		return nil, nil
-	}
-	_ = handler
-
 	makeHandler := func(command string) CommandHandler {
-		return func(ctx context.Context, input json.RawMessage) (json.RawMessage, error) {
+		return func(ctx context.Context, input json.RawMessage, _ ChunkFunc) (json.RawMessage, error) {
 			return invoker.HandleCommand(ctx, command, input)
 		}
 	}

--- a/internal/daemon/connect.go
+++ b/internal/daemon/connect.go
@@ -64,18 +64,6 @@ func (h *HubService) ListClips(context.Context, *connect.Request[pinixv2.ListCli
 	if h.daemon != nil && h.daemon.provider != nil {
 		clips = append(clips, h.daemon.provider.ListClipInfos()...)
 	}
-	// Add agent virtual clip
-	if h.daemon != nil && h.daemon.agentHandler != nil {
-		clips = append(clips, &pinixv2.ClipInfo{
-			Name:        "agent",
-			Package:     "@pinix/agent",
-			Version:     "1.0.0",
-			Domain:      "ai",
-			Description: "Built-in AI Agent Runtime",
-			Provider:    "local",
-			Status:      pinixv2.ClipStatus_CLIP_STATUS_RUNNING,
-		})
-	}
 	// Add builtin clips
 	if h.daemon != nil && h.daemon.builtin != nil {
 		for _, bc := range h.daemon.builtin.List() {
@@ -222,43 +210,28 @@ func (h *HubService) Invoke(ctx context.Context, req *connect.Request[pinixv2.In
 		return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("command is required"))
 	}
 
-	// Agent virtual clip: intercept BEFORE resolveClipName (agent is not in registry)
-	reqClipName := strings.TrimSpace(req.Msg.GetClipName())
-	if reqClipName == "agent" && h.daemon != nil && h.daemon.agentHandler != nil {
-		slog.Info("hub.invoke: start",
-			"trace_id", traceID, "target", "agent", "command", command, "route", "agent",
-		)
-		err := h.invokeAgentClip(ctx, command, req.Msg.GetInput(), stream)
-		if err != nil {
-			slog.Error("hub.invoke: error",
-				"trace_id", traceID, "target", "agent", "command", command,
-				"route", "agent", "duration_ms", time.Since(start).Milliseconds(), "error", err,
-			)
-		} else {
-			slog.Info("hub.invoke: done",
-				"trace_id", traceID, "target", "agent", "command", command,
-				"route", "agent", "duration_ms", time.Since(start).Milliseconds(),
-			)
-		}
-		return err
-	}
-
 	// Builtin clips: intercept BEFORE resolveClipName (builtins are not in registry)
+	reqClipName := strings.TrimSpace(req.Msg.GetClipName())
 	if h.daemon != nil && h.daemon.builtin != nil {
 		if clip, ok := h.daemon.builtin.Get(reqClipName); ok {
 			slog.Info("hub.invoke: start",
 				"trace_id", traceID, "target", reqClipName, "command", command, "route", "builtin",
 			)
-			output, invokeErr := clip.Invoke(ctx, command, req.Msg.GetInput())
+			onChunk := func(chunk json.RawMessage) {
+				_ = stream.Send(&pinixv2.InvokeResponse{Output: chunk})
+			}
+			output, invokeErr := clip.Invoke(ctx, command, req.Msg.GetInput(), onChunk)
 			if invokeErr != nil {
 				slog.Error("hub.invoke: error",
 					"trace_id", traceID, "target", reqClipName, "command", command,
 					"route", "builtin", "duration_ms", time.Since(start).Milliseconds(), "error", invokeErr,
 				)
-				return connect.NewError(connect.CodeInternal, invokeErr)
+				return sendInvokeApplicationError(stream, invokeErr)
 			}
-			if err := stream.Send(&pinixv2.InvokeResponse{Output: output}); err != nil {
-				return err
+			if len(output) > 0 {
+				if err := stream.Send(&pinixv2.InvokeResponse{Output: output}); err != nil {
+					return err
+				}
 			}
 			slog.Info("hub.invoke: done",
 				"trace_id", traceID, "target", reqClipName, "command", command,
@@ -913,21 +886,6 @@ func (h *HubService) invokeProviderClipCallback(ctx context.Context, clipName, c
 			return nil
 		}
 	}
-}
-
-func (h *HubService) invokeAgentClip(ctx context.Context, command string, input []byte, stream *connect.ServerStream[pinixv2.InvokeResponse]) error {
-	onChunk := func(chunk json.RawMessage) {
-		_ = stream.Send(&pinixv2.InvokeResponse{Output: chunk})
-	}
-
-	result, err := h.daemon.agentHandler.HandleInvoke(ctx, command, json.RawMessage(input), onChunk)
-	if err != nil {
-		return sendInvokeApplicationError(stream, err)
-	}
-	if len(result) > 0 {
-		_ = stream.Send(&pinixv2.InvokeResponse{Output: result})
-	}
-	return nil
 }
 
 func (h *HubService) invokeLocalClip(ctx context.Context, clip ClipConfig, command string, input []byte, clipToken string, stream *connect.ServerStream[pinixv2.InvokeResponse]) error {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -23,14 +23,13 @@ import (
 )
 
 type Daemon struct {
-	registry     *Registry
-	process      *ProcessManager
-	provider     *ProviderManager
-	runtime      *RuntimeManager
-	handler      *Handler
-	scheduler    *Scheduler
-	agentHandler *agent.Handler
-	builtin      *builtin.Registry
+	registry  *Registry
+	process   *ProcessManager
+	provider  *ProviderManager
+	runtime   *RuntimeManager
+	handler   *Handler
+	scheduler *Scheduler
+	builtin   *builtin.Registry
 
 	mu         sync.Mutex
 	httpServer *http.Server
@@ -50,12 +49,13 @@ func NewDaemon(registry *Registry, process *ProcessManager) (*Daemon, error) {
 		process:  process,
 		provider: NewProviderManager(registry),
 		runtime:  NewRuntimeManager(),
+		builtin:  builtin.NewRegistry(),
 	}
 	d.process.provider = d.provider
 	d.provider.registry = registry
 	d.handler = NewHandler(registry, process)
 
-	// Initialize agent runtime
+	// Register builtin clips
 	d.initAgentRuntime()
 
 	return d, nil
@@ -76,7 +76,8 @@ func (d *Daemon) initAgentRuntime() {
 	}
 
 	rt := agent.NewRuntime(store, invoker, getClips)
-	d.agentHandler = agent.NewHandler(rt)
+	handler := agent.NewHandler(rt)
+	d.builtin.Register(builtin.NewAgentClip(handler))
 	slog.Info("agent: runtime initialized", "data_dir", dataDir)
 }
 
@@ -197,9 +198,10 @@ func NewHubDaemon(registry *Registry) (*Daemon, error) {
 		registry: registry,
 		provider: NewProviderManager(nil),
 		runtime:  NewRuntimeManager(),
+		builtin:  builtin.NewRegistry(),
 	}
 
-	// Initialize agent runtime (also in hub-only mode)
+	// Register builtin clips (also in hub-only mode)
 	d.initAgentRuntime()
 
 	return d, nil
@@ -215,9 +217,6 @@ func (d *Daemon) SetScheduler(s *Scheduler) {
 	d.scheduler = s
 
 	// Register builtin scheduler Clip
-	if d.builtin == nil {
-		d.builtin = builtin.NewRegistry()
-	}
 	d.builtin.Register(builtin.NewSchedulerClip(NewSchedulerClipHandler(s)))
 
 	// When a provider registers a clip with schedule declarations, auto-register them.

--- a/internal/daemon/runtime_hub.go
+++ b/internal/daemon/runtime_hub.go
@@ -19,6 +19,7 @@ import (
 
 	connect "connectrpc.com/connect"
 	pinixv2 "github.com/epiral/pinix/gen/go/pinix/v2"
+	"github.com/epiral/pinix/internal/builtin"
 	clientpkg "github.com/epiral/pinix/internal/client"
 	"github.com/epiral/pinix/internal/ipc"
 )
@@ -346,9 +347,11 @@ func (c *runtimeHubConnector) registerMessage(ctx context.Context) (*pinixv2.Pro
 		registrations = append(registrations, localClipToRegistration(clip))
 	}
 
-	// Register the built-in agent virtual clip so it appears on remote Hubs
-	if c.daemon.agentHandler != nil {
-		registrations = append(registrations, agentClipRegistration())
+	// Register builtin clips so they appear on remote Hubs
+	if c.daemon.builtin != nil {
+		for _, bc := range c.daemon.builtin.List() {
+			registrations = append(registrations, builtinClipToRegistration(bc))
+		}
 	}
 
 	select {
@@ -493,22 +496,24 @@ func (c *runtimeHubConnector) handleInvokeCommand(ctx context.Context, stream *c
 		return
 	}
 
-	// Agent virtual clip: route to built-in Go Agent Runtime
-	if clipName == "agent" && c.daemon.agentHandler != nil {
-		onChunk := func(chunk json.RawMessage) {
-			_ = c.sendInvokeResult(stream, &pinixv2.InvokeResult{RequestId: requestID, Output: chunk})
-		}
-		result, err := c.daemon.agentHandler.HandleInvoke(ctx, commandName, json.RawMessage(command.GetInput()), onChunk)
-		if err != nil {
-			c.sendInvokeError(stream, requestID, err)
+	// Builtin clips: route to in-process handlers
+	if c.daemon.builtin != nil {
+		if bc, ok := c.daemon.builtin.Get(clipName); ok {
+			onChunk := func(chunk json.RawMessage) {
+				_ = c.sendInvokeResult(stream, &pinixv2.InvokeResult{RequestId: requestID, Output: chunk})
+			}
+			result, err := bc.Invoke(ctx, commandName, json.RawMessage(command.GetInput()), onChunk)
+			if err != nil {
+				c.sendInvokeError(stream, requestID, err)
+				return
+			}
+			if len(result) > 0 {
+				_ = c.sendInvokeResult(stream, &pinixv2.InvokeResult{RequestId: requestID, Output: result, Done: true})
+			} else {
+				_ = c.sendInvokeResult(stream, &pinixv2.InvokeResult{RequestId: requestID, Output: []byte(`{}`), Done: true})
+			}
 			return
 		}
-		if len(result) > 0 {
-			_ = c.sendInvokeResult(stream, &pinixv2.InvokeResult{RequestId: requestID, Output: result, Done: true})
-		} else {
-			_ = c.sendInvokeResult(stream, &pinixv2.InvokeResult{RequestId: requestID, Output: []byte(`{}`), Done: true})
-		}
-		return
 	}
 
 	clip, ok, err := c.daemon.registry.GetClip(clipName)
@@ -862,36 +867,23 @@ func localClipToRegistration(clip ClipConfig) *pinixv2.ClipRegistration {
 	}
 }
 
-// agentClipRegistration returns a ClipRegistration for the built-in agent virtual clip.
-func agentClipRegistration() *pinixv2.ClipRegistration {
+// builtinClipToRegistration converts a builtin.Clip to a proto ClipRegistration.
+func builtinClipToRegistration(bc *builtin.Clip) *pinixv2.ClipRegistration {
+	cmds := make([]*pinixv2.CommandInfo, 0, len(bc.Commands))
+	for _, c := range bc.Commands {
+		cmds = append(cmds, &pinixv2.CommandInfo{
+			Name:        c.Name,
+			Description: c.Description,
+			Input:       c.Input,
+		})
+	}
 	return &pinixv2.ClipRegistration{
-		Alias:       "agent",
-		Package:     "@pinix/agent",
-		Version:     "1.0.0",
-		Domain:      "ai",
-		Description: "Built-in AI Agent Runtime",
-		Commands: []*pinixv2.CommandInfo{
-			{Name: "chat", Description: "Send a message and get a streaming response",
-				Input: `{"type":"object","properties":{"agent_id":{"type":"string"},"topic_id":{"type":"string"},"message":{"type":"string"}},"required":["agent_id","message"]}`},
-			{Name: "topic list", Description: "List all topics for an agent"},
-			{Name: "topic get", Description: "Get topic details with messages"},
-			{Name: "topic create", Description: "Create a new topic"},
-			{Name: "topic delete", Description: "Delete a topic"},
-			{Name: "topic rename", Description: "Rename a topic"},
-			{Name: "topic search", Description: "Search across topics"},
-			{Name: "run get", Description: "Get run details"},
-			{Name: "run cancel", Description: "Cancel a running run"},
-			{Name: "agent list", Description: "List all agent configurations"},
-			{Name: "agent get", Description: "Get agent details"},
-			{Name: "agent create", Description: "Create a new agent"},
-			{Name: "agent update", Description: "Update agent configuration"},
-			{Name: "agent delete", Description: "Delete an agent"},
-			{Name: "event create", Description: "Create a scheduled event"},
-			{Name: "event list", Description: "List scheduled events"},
-			{Name: "event update", Description: "Update a scheduled event"},
-			{Name: "event cancel", Description: "Cancel a scheduled event"},
-			{Name: "config get", Description: "Get global agent configuration"},
-		},
+		Alias:       bc.Name,
+		Package:     bc.Package,
+		Version:     bc.Version,
+		Domain:      bc.Domain,
+		Description: bc.Description,
+		Commands:    cmds,
 	}
 }
 


### PR DESCRIPTION
Closes #146

## Summary

All builtin clips (agent, scheduler) now go through a single `internal/builtin/` framework. No more hardcoded intercepts.

## Before → After

**Before**: Agent had hardcoded intercepts in 4 places (daemon.go agentHandler field, connect.go invoke, connect.go ListClips, runtime_hub.go ProviderStream + InvokeCommand). Scheduler used builtin framework but was incomplete (no ProviderStream registration).

**After**: One code path for all builtin clips:
- `d.builtin.Get(name)` in connect.go Invoke
- `d.builtin.List()` in connect.go ListClips
- `d.builtin.List()` in runtime_hub.go registerMessage (ProviderStream)
- `d.builtin.Get(name)` in runtime_hub.go handleInvokeCommand

## Key changes

- `CommandHandler` now accepts `onChunk ChunkFunc` for streaming support
- New `internal/builtin/agent.go` — thin bridge from agent.Handler to builtin.Clip
- Removed `daemon.agentHandler` field, `invokeAgentClip()`, `agentClipRegistration()`
- `builtin.Registry` created in `NewDaemon()`/`NewHubDaemon()` (not lazily)
- Both agent and scheduler now register to Cloud Hub via ProviderStream

Net: -51 lines, +1 file, simpler architecture.

## Verify

- `go build ./...` pass
- `go vet ./...` clean
- `go test ./...` pass