### PR TITLE
fix(agent): generate topic title for pre-created empty-title topics

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -96,9 +96,11 @@ func (r *Runtime) Chat(ctx context.Context, input ChatInput, onEvent func(Stream
 	// Update topic timestamp
 	_ = r.store.SaveTopic(topic)
 
-	// Generate title asynchronously if this is a new topic
-	if topic.Title == truncate(input.Message, 30) {
-		go r.generateTopicTitle(agt, topic, input.Message)
+	// Generate title if this topic has no meaningful title yet.
+	// This covers both: (1) topics created by Chat() itself (title = truncated message),
+	// and (2) topics pre-created by the frontend with an empty title.
+	if topic.Title == "" || topic.Title == truncate(input.Message, 30) {
+		r.generateTopicTitle(agt, topic, input.Message)
 	}
 
 	if loopErr != nil && ctx.Err() == nil {


### PR DESCRIPTION
## Problem

The frontend creates topics via `topic create` before sending the first chat message. These topics have empty titles. The title generation logic in `Chat()` only triggered when `topic.Title == truncate(input.Message, 30)`, which never matches for empty-title topics.

Additionally, `generateTopicTitle` was called asynchronously (goroutine), causing a race condition where the frontend would reload the topic immediately after the `done` stream event but before the title was written to the database.

## Root Cause

```
Frontend flow: topic create (empty title) → chat (with topic_id)
Go runtime:   GetTopic → title is "" → condition "" == truncate(msg, 30) → false → skip title generation
```

## Fix

1. Changed condition to also trigger when `topic.Title == ""`
2. Changed `generateTopicTitle` from async to synchronous so the title is available when the frontend reloads after the `done` event

## Verification

- `go build` passes
- `go vet` clean
- Sidebar topic titles should now be auto-generated after the first chat message