### PR TITLE
feat(scheduler): persist execution history to SQLite

### DIFF
--- a/cmd/pinix/daemon.go
+++ b/cmd/pinix/daemon.go
@@ -189,7 +189,7 @@ func runDaemon(opts daemonOptions) error {
 		defer func() { _ = d.Close() }()
 
 		// Start scheduler (invokes through external Hub)
-		sched := daemon.NewScheduler(registry, hubURL)
+		sched := daemon.NewScheduler(registry, hubURL, filepath.Join(registry.RootDir(), "data", "scheduler"))
 		sched.SetHubToken(hubToken)
 		d.SetScheduler(sched)
 		if err := sched.Start(); err != nil {
@@ -209,7 +209,7 @@ func runDaemon(opts daemonOptions) error {
 	}
 
 	// Start scheduler on hubDaemon (invokes through local Hub)
-	sched := daemon.NewScheduler(registry, localHubURL)
+	sched := daemon.NewScheduler(registry, localHubURL, filepath.Join(registry.RootDir(), "data", "scheduler"))
 	hubDaemon.SetScheduler(sched)
 	if err := sched.Start(); err != nil {
 		slog.Warn("scheduler: failed to start", "error", err)

--- a/cmd/pinixd/main.go
+++ b/cmd/pinixd/main.go
@@ -159,7 +159,7 @@ func main() {
 		defer func() { _ = d.Close() }()
 
 		// Start scheduler (invokes through external Hub)
-		sched := daemon.NewScheduler(registry, hubURL)
+		sched := daemon.NewScheduler(registry, hubURL, filepath.Join(registry.RootDir(), "data", "scheduler"))
 		sched.SetHubToken(hubToken)
 		d.SetScheduler(sched)
 		if err := sched.Start(); err != nil {
@@ -183,7 +183,7 @@ func main() {
 	}
 
 	// Start scheduler on hubDaemon (invokes through local Hub)
-	sched := daemon.NewScheduler(registry, localHubURL)
+	sched := daemon.NewScheduler(registry, localHubURL, filepath.Join(registry.RootDir(), "data", "scheduler"))
 	hubDaemon.SetScheduler(sched)
 	if err := sched.Start(); err != nil {
 		slog.Warn("scheduler: failed to start", "error", err)

--- a/internal/daemon/scheduler.go
+++ b/internal/daemon/scheduler.go
@@ -45,6 +45,7 @@ type scheduleEntry struct {
 // Scheduler manages cron-triggered Clip invokes.
 type Scheduler struct {
 	registry *Registry
+	store    *SchedulerStore
 	hubURL   string
 	hubToken string
 
@@ -53,25 +54,34 @@ type Scheduler struct {
 	mu      sync.RWMutex
 	entries map[string]*scheduleEntry // schedule ID -> entry
 
-	historyMu sync.RWMutex
-	history   map[string][]ScheduleExecution // schedule ID -> recent executions (ring buffer)
-
 	ctx    context.Context
 	cancel context.CancelFunc
 }
 
 // NewScheduler creates a new scheduler. Call Start() to begin scheduling.
-func NewScheduler(registry *Registry, hubURL string) *Scheduler {
+// dataDir is the directory for the SQLite database (e.g. ~/.pinix/data/scheduler).
+func NewScheduler(registry *Registry, hubURL string, dataDir string) *Scheduler {
 	ctx, cancel := context.WithCancel(context.Background())
-	return &Scheduler{
+	s := &Scheduler{
 		registry: registry,
 		hubURL:   hubURL,
 		cron:     cron.New(cron.WithParser(cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow))),
 		entries:  make(map[string]*scheduleEntry),
-		history:  make(map[string][]ScheduleExecution),
 		ctx:      ctx,
 		cancel:   cancel,
 	}
+
+	// Open SQLite store for execution history
+	if dataDir != "" {
+		store, err := NewSchedulerStore(dataDir)
+		if err != nil {
+			slog.Warn("scheduler: failed to open history store, history will not persist", "error", err)
+		} else {
+			s.store = store
+		}
+	}
+
+	return s
 }
 
 // SetHubToken sets the hub auth token for scheduled invokes.
@@ -170,6 +180,9 @@ func (s *Scheduler) Stop() {
 	s.cancel()
 	ctx := s.cron.Stop()
 	<-ctx.Done()
+	if s.store != nil {
+		_ = s.store.Close()
+	}
 	slog.Info("scheduler: stopped")
 }
 
@@ -212,9 +225,10 @@ func (s *Scheduler) Remove(id string) error {
 		return fmt.Errorf("schedule %q not found", id)
 	}
 
-	s.historyMu.Lock()
-	delete(s.history, id)
-	s.historyMu.Unlock()
+	// Clean up execution history
+	if s.store != nil {
+		_ = s.store.DeleteExecutions(id)
+	}
 
 	slog.Info("scheduler: removed", "id", id)
 	return nil
@@ -305,13 +319,12 @@ func (s *Scheduler) List() ([]ScheduleStatus, error) {
 				status.NextRun = &cronEntry.Next
 			}
 		}
-		// Attach last execution
-		s.historyMu.RLock()
-		if hist, ok := s.history[sc.ID]; ok && len(hist) > 0 {
-			last := hist[len(hist)-1]
-			status.LastRun = &last
+		// Attach last execution from store
+		if s.store != nil {
+			if last := s.store.LastExecution(sc.ID); last != nil {
+				status.LastRun = last
+			}
 		}
-		s.historyMu.RUnlock()
 
 		result = append(result, status)
 	}
@@ -320,17 +333,15 @@ func (s *Scheduler) List() ([]ScheduleStatus, error) {
 
 // History returns recent executions for a schedule.
 func (s *Scheduler) History(id string) []ScheduleExecution {
-	s.historyMu.RLock()
-	defer s.historyMu.RUnlock()
-
-	hist, ok := s.history[id]
-	if !ok {
+	if s.store == nil {
 		return nil
 	}
-	// Return a copy
-	out := make([]ScheduleExecution, len(hist))
-	copy(out, hist)
-	return out
+	execs, err := s.store.ListExecutions(id, maxHistoryPerSchedule)
+	if err != nil {
+		slog.Warn("scheduler: failed to read history", "id", id, "error", err)
+		return nil
+	}
+	return execs
 }
 
 // ScheduleStatus is a schedule config with runtime status.
@@ -417,13 +428,9 @@ func (s *Scheduler) recordExecution(id string, startedAt time.Time, output json.
 		)
 	}
 
-	s.historyMu.Lock()
-	defer s.historyMu.Unlock()
-
-	hist := s.history[id]
-	hist = append(hist, exec)
-	if len(hist) > maxHistoryPerSchedule {
-		hist = hist[len(hist)-maxHistoryPerSchedule:]
+	if s.store != nil {
+		if err := s.store.RecordExecution(exec); err != nil {
+			slog.Warn("scheduler: failed to persist execution", "id", id, "error", err)
+		}
 	}
-	s.history[id] = hist
 }

--- a/internal/daemon/scheduler_store.go
+++ b/internal/daemon/scheduler_store.go
@@ -1,0 +1,160 @@
+// Role:    SQLite storage for scheduler execution history
+// Depends: database/sql, encoding/json, fmt, os, path/filepath, time, modernc.org/sqlite
+// Exports: SchedulerStore, NewSchedulerStore
+
+package daemon
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// SchedulerStore persists schedule execution history to SQLite.
+type SchedulerStore struct {
+	db *sql.DB
+}
+
+// NewSchedulerStore opens or creates the scheduler SQLite database.
+func NewSchedulerStore(dataDir string) (*SchedulerStore, error) {
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		return nil, fmt.Errorf("create scheduler data dir: %w", err)
+	}
+
+	dbPath := filepath.Join(dataDir, "scheduler.db")
+	db, err := sql.Open("sqlite", dbPath+"?_pragma=journal_mode(wal)&_pragma=busy_timeout(5000)")
+	if err != nil {
+		return nil, fmt.Errorf("open scheduler database: %w", err)
+	}
+
+	s := &SchedulerStore{db: db}
+	if err := s.migrate(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("migrate scheduler database: %w", err)
+	}
+	return s, nil
+}
+
+// Close closes the database.
+func (s *SchedulerStore) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+func (s *SchedulerStore) migrate() error {
+	_, err := s.db.Exec(`
+		CREATE TABLE IF NOT EXISTS executions (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			schedule_id TEXT NOT NULL,
+			started_at TEXT NOT NULL,
+			finished_at TEXT NOT NULL,
+			duration_ms INTEGER NOT NULL DEFAULT 0,
+			success INTEGER NOT NULL DEFAULT 0,
+			output TEXT DEFAULT '',
+			error TEXT DEFAULT '',
+			created_at TEXT NOT NULL DEFAULT (datetime('now'))
+		);
+		CREATE INDEX IF NOT EXISTS idx_executions_schedule ON executions(schedule_id, id DESC);
+	`)
+	return err
+}
+
+// RecordExecution inserts an execution record.
+func (s *SchedulerStore) RecordExecution(exec ScheduleExecution) error {
+	outputStr := ""
+	if len(exec.Output) > 0 {
+		outputStr = string(exec.Output)
+	}
+	_, err := s.db.Exec(
+		`INSERT INTO executions (schedule_id, started_at, finished_at, duration_ms, success, output, error)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		exec.ScheduleID,
+		exec.StartedAt.Format(time.RFC3339),
+		exec.FinishedAt.Format(time.RFC3339),
+		exec.DurationMs,
+		boolToInt(exec.Success),
+		outputStr,
+		exec.Error,
+	)
+	return err
+}
+
+// ListExecutions returns the most recent executions for a schedule.
+func (s *SchedulerStore) ListExecutions(scheduleID string, limit int) ([]ScheduleExecution, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	rows, err := s.db.Query(
+		`SELECT schedule_id, started_at, finished_at, duration_ms, success, output, error
+		 FROM executions WHERE schedule_id = ? ORDER BY id DESC LIMIT ?`,
+		scheduleID, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var execs []ScheduleExecution
+	for rows.Next() {
+		var (
+			e         ScheduleExecution
+			startStr  string
+			finishStr string
+			success   int
+			output    string
+		)
+		if err := rows.Scan(&e.ScheduleID, &startStr, &finishStr, &e.DurationMs, &success, &output, &e.Error); err != nil {
+			return nil, err
+		}
+		e.StartedAt, _ = time.Parse(time.RFC3339, startStr)
+		e.FinishedAt, _ = time.Parse(time.RFC3339, finishStr)
+		e.Success = success != 0
+		if output != "" {
+			e.Output = json.RawMessage(output)
+		}
+		execs = append(execs, e)
+	}
+	return execs, rows.Err()
+}
+
+// LastExecution returns the most recent execution for a schedule, or nil.
+func (s *SchedulerStore) LastExecution(scheduleID string) *ScheduleExecution {
+	execs, err := s.ListExecutions(scheduleID, 1)
+	if err != nil || len(execs) == 0 {
+		return nil
+	}
+	return &execs[0]
+}
+
+// DeleteExecutions removes all execution records for a schedule.
+func (s *SchedulerStore) DeleteExecutions(scheduleID string) error {
+	_, err := s.db.Exec(`DELETE FROM executions WHERE schedule_id = ?`, scheduleID)
+	return err
+}
+
+// Cleanup removes old execution records, keeping at most maxPerSchedule per schedule.
+func (s *SchedulerStore) Cleanup(maxPerSchedule int) error {
+	_, err := s.db.Exec(`
+		DELETE FROM executions WHERE id NOT IN (
+			SELECT id FROM (
+				SELECT id, ROW_NUMBER() OVER (PARTITION BY schedule_id ORDER BY id DESC) AS rn
+				FROM executions
+			) WHERE rn <= ?
+		)
+	`, maxPerSchedule)
+	return err
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}


### PR DESCRIPTION
Replace in-memory ring buffer with SQLite at `~/.pinix/data/scheduler/scheduler.db`. History now survives pinixd restarts.

New file: `internal/daemon/scheduler_store.go` — SQLite CRUD with auto-migrate, WAL mode, cleanup.