### PR TITLE
feat(cli): org management commands + publish --access flag

### DIFF
--- a/cmd/pinix/main.go
+++ b/cmd/pinix/main.go
@@ -70,6 +70,7 @@ Docker:
 	rootCmd.AddCommand(newInvokeCommand())
 	rootCmd.AddCommand(newDataCommand())
 	rootCmd.AddCommand(newHubCommand())
+	rootCmd.AddCommand(newOrgGroupCommand())
 	rootCmd.AddCommand(newRegistryGroupCommand())
 	rootCmd.AddCommand(newConfigCommand())
 	rootCmd.AddCommand(newScheduleCommand())

--- a/cmd/pinix/org_cmd.go
+++ b/cmd/pinix/org_cmd.go
@@ -1,0 +1,177 @@
+// Role:    Organization management subcommand group for the pinix CLI
+// Depends: cobra, internal/client
+// Exports: newOrgGroupCommand
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newOrgGroupCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "org",
+		Short: "Manage organizations",
+	}
+	cmd.AddCommand(newOrgCreateCommand())
+	cmd.AddCommand(newOrgListCommand())
+	cmd.AddCommand(newOrgMembersCommand())
+	cmd.AddCommand(newOrgAddMemberCommand())
+	cmd.AddCommand(newOrgRemoveMemberCommand())
+	return cmd
+}
+
+func newOrgCreateCommand() *cobra.Command {
+	var registryURL string
+
+	cmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a new organization",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reg, err := requireRegistryClient(registryURL)
+			if err != nil {
+				return err
+			}
+			token, err := loadRegistryToken(reg.BaseURL())
+			if err != nil {
+				return err
+			}
+			org, err := reg.CreateOrg(cmd.Context(), token, strings.TrimSpace(args[0]))
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "created organization %s (id: %s)\n", org.Name, org.ID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL")
+	return cmd
+}
+
+func newOrgListCommand() *cobra.Command {
+	var registryURL string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List organizations you belong to",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reg, err := requireRegistryClient(registryURL)
+			if err != nil {
+				return err
+			}
+			token, err := loadRegistryToken(reg.BaseURL())
+			if err != nil {
+				return err
+			}
+			resp, err := reg.ListUserOrgs(cmd.Context(), token)
+			if err != nil {
+				return err
+			}
+			if len(resp.Orgs) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "(no organizations)")
+				return nil
+			}
+			for _, org := range resp.Orgs {
+				fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\n", org.ID, org.Name)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL")
+	return cmd
+}
+
+func newOrgMembersCommand() *cobra.Command {
+	var registryURL string
+
+	cmd := &cobra.Command{
+		Use:   "members <org-id>",
+		Short: "List members of an organization",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reg, err := requireRegistryClient(registryURL)
+			if err != nil {
+				return err
+			}
+			resp, err := reg.ListOrgMembers(cmd.Context(), strings.TrimSpace(args[0]))
+			if err != nil {
+				return err
+			}
+			if len(resp.Members) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "(no members)")
+				return nil
+			}
+			for _, m := range resp.Members {
+				fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\n", m.UserID, m.Role)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL")
+	return cmd
+}
+
+func newOrgAddMemberCommand() *cobra.Command {
+	var registryURL string
+	var role string
+
+	cmd := &cobra.Command{
+		Use:   "add-member <org-id> <username>",
+		Short: "Add a member to an organization",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reg, err := requireRegistryClient(registryURL)
+			if err != nil {
+				return err
+			}
+			token, err := loadRegistryToken(reg.BaseURL())
+			if err != nil {
+				return err
+			}
+			orgID := strings.TrimSpace(args[0])
+			username := strings.TrimSpace(args[1])
+			if err := reg.AddOrgMember(cmd.Context(), token, orgID, username, role); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "added %s to organization as %s\n", username, role)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL")
+	cmd.Flags().StringVar(&role, "role", "member", "Role: owner or member")
+	return cmd
+}
+
+func newOrgRemoveMemberCommand() *cobra.Command {
+	var registryURL string
+
+	cmd := &cobra.Command{
+		Use:   "remove-member <org-id> <user-id>",
+		Short: "Remove a member from an organization",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reg, err := requireRegistryClient(registryURL)
+			if err != nil {
+				return err
+			}
+			token, err := loadRegistryToken(reg.BaseURL())
+			if err != nil {
+				return err
+			}
+			orgID := strings.TrimSpace(args[0])
+			userID := strings.TrimSpace(args[1])
+			if err := reg.RemoveOrgMember(cmd.Context(), token, orgID, userID); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "removed %s from organization\n", userID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL")
+	return cmd
+}

--- a/cmd/pinix/registry.go
+++ b/cmd/pinix/registry.go
@@ -24,20 +24,21 @@ import (
 )
 
 type registryPublishManifest struct {
-	Name         string            `json:"name"`
-	Version      string            `json:"version"`
-	Type         string            `json:"type"`
-	Description  string            `json:"description"`
-	Domain       string            `json:"domain,omitempty"`
-	Runtime      string            `json:"runtime,omitempty"`
-	Main         string            `json:"main,omitempty"`
-	Web          string            `json:"web,omitempty"`
-	Author       string            `json:"author,omitempty"`
-	License      string            `json:"license,omitempty"`
-	Repository   string            `json:"repository,omitempty"`
-	Commands     []daemonpkg.CommandInfo          `json:"commands,omitempty"`
-	Dependencies map[string]daemonpkg.DependencySpec `json:"dependencies,omitempty"`
-	Patterns     []string          `json:"patterns,omitempty"`
+	Name         string                              `json:"name"`
+	Version      string                              `json:"version"`
+	Type         string                              `json:"type"`
+	Description  string                              `json:"description"`
+	Access       string                              `json:"access,omitempty"`
+	Domain       string                              `json:"domain,omitempty"`
+	Runtime      string                              `json:"runtime,omitempty"`
+	Main         string                              `json:"main,omitempty"`
+	Web          string                              `json:"web,omitempty"`
+	Author       string                              `json:"author,omitempty"`
+	License      string                              `json:"license,omitempty"`
+	Repository   string                              `json:"repository,omitempty"`
+	Commands     []daemonpkg.CommandInfo              `json:"commands,omitempty"`
+	Dependencies map[string]daemonpkg.DependencySpec  `json:"dependencies,omitempty"`
+	Patterns     []string                             `json:"patterns,omitempty"`
 }
 
 type localPackageJSON struct {
@@ -85,6 +86,7 @@ func newSearchCommand() *cobra.Command {
 func newPublishCommand() *cobra.Command {
 	var registryURL string
 	var tag string
+	var access string
 
 	cmd := &cobra.Command{
 		Use:   "publish [path]",
@@ -96,10 +98,25 @@ func newPublishCommand() *cobra.Command {
 				dir = args[0]
 			}
 
+			access = strings.TrimSpace(access)
+			if access != "" && access != "public" && access != "private" && access != "restricted" {
+				return fmt.Errorf("--access must be one of: public, private, restricted")
+			}
+
 			manifestRaw, manifest, err := loadRegistryPublishManifest(dir)
 			if err != nil {
 				return err
 			}
+
+			// Apply --access flag to manifest if specified.
+			if access != "" {
+				manifest.Access = access
+				manifestRaw, err = json.Marshal(manifest)
+				if err != nil {
+					return fmt.Errorf("marshal manifest with access: %w", err)
+				}
+			}
+
 			tarball, err := buildRegistryTarball(dir)
 			if err != nil {
 				return err
@@ -126,6 +143,7 @@ func newPublishCommand() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&registryURL, "registry", "", "Pinix Registry base URL (default: from config or https://api.pinixai.com)")
 	cmd.Flags().StringVar(&tag, "tag", "", "dist-tag to publish under")
+	cmd.Flags().StringVar(&access, "access", "", "access level: public, private, or restricted")
 	return cmd
 }
 

--- a/internal/client/registry.go
+++ b/internal/client/registry.go
@@ -345,6 +345,85 @@ func (c *RegistryClient) WhoAmI(ctx context.Context, token string) (*RegistryAut
 	return &resp, nil
 }
 
+// --- Organization management ---
+
+type OrgResponse struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	CreatedAt string `json:"created_at"`
+}
+
+type OrgMemberResponse struct {
+	OrgID  string `json:"org_id"`
+	UserID string `json:"user_id"`
+	Role   string `json:"role"`
+}
+
+type ListOrgsResponse struct {
+	Orgs []OrgResponse `json:"orgs"`
+}
+
+type ListOrgMembersResponse struct {
+	Members []OrgMemberResponse `json:"members"`
+}
+
+func (c *RegistryClient) CreateOrg(ctx context.Context, token, name string) (*OrgResponse, error) {
+	payload := map[string]string{"name": name}
+	var resp OrgResponse
+	if err := c.postJSON(ctx, "/orgs", payload, token, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *RegistryClient) ListUserOrgs(ctx context.Context, token string) (*ListOrgsResponse, error) {
+	var resp ListOrgsResponse
+	if err := c.doJSON(ctx, http.MethodGet, "/users/me/orgs", nil, "application/json", token, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *RegistryClient) GetOrg(ctx context.Context, orgID string) (*OrgResponse, error) {
+	var resp OrgResponse
+	if err := c.getJSON(ctx, "/orgs/"+url.PathEscape(orgID), &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *RegistryClient) ListOrgMembers(ctx context.Context, orgID string) (*ListOrgMembersResponse, error) {
+	var resp ListOrgMembersResponse
+	if err := c.getJSON(ctx, "/orgs/"+url.PathEscape(orgID)+"/members", &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *RegistryClient) AddOrgMember(ctx context.Context, token, orgID, username, role string) error {
+	payload := map[string]string{
+		"username": username,
+		"role":     role,
+	}
+	return c.postJSON(ctx, "/orgs/"+url.PathEscape(orgID)+"/members", payload, token, nil)
+}
+
+func (c *RegistryClient) RemoveOrgMember(ctx context.Context, token, orgID, userID string) error {
+	path := "/orgs/" + url.PathEscape(orgID) + "/members/" + url.PathEscape(userID)
+	return c.doJSON(ctx, http.MethodDelete, path, nil, "application/json", token, nil)
+}
+
+// SetAccess changes the access level of a package.
+func (c *RegistryClient) SetAccess(ctx context.Context, token, name, access string) error {
+	path := packagePath(name) + "/access"
+	payload := map[string]string{"access": access}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal access request: %w", err)
+	}
+	return c.doJSON(ctx, http.MethodPut, path, bytes.NewReader(data), "application/json", token, nil)
+}
+
 func (c *RegistryClient) SetDistTag(ctx context.Context, name, tag, version, token string) error {
 	name = strings.TrimSpace(name)
 	tag = strings.TrimSpace(tag)


### PR DESCRIPTION
## Summary

CLI support for organization management and package visibility control.

### New Commands

- `pinix org create <name>` — create a new organization
- `pinix org list` — list organizations you belong to
- `pinix org members <org-id>` — list members of an organization
- `pinix org add-member <org-id> <username> [--role owner|member]` — add a member
- `pinix org remove-member <org-id> <user-id>` — remove a member

### New Flag

- `pinix registry publish --access public|private|restricted` — set package visibility on publish

### Client Changes

Added org and access methods to `RegistryClient`:
- CreateOrg, ListUserOrgs, GetOrg, ListOrgMembers, AddOrgMember, RemoveOrgMember
- SetAccess

Closes #154

**Depends on:** epiral/pinix.ai#47