### PR TITLE
feat(proto): ClipInfo sharing fields (source, owner, price_per_invoke)

### DIFF
--- a/proto/pinix/v2/hub.proto
+++ b/proto/pinix/v2/hub.proto
@@ -72,6 +72,10 @@ message ClipInfo {
   ClipStatus status = 10;
   string status_message = 11;
   string description = 12;
+  // Sharing: set when the clip is from another scope via Clip Sharing.
+  string source = 13; // "" = local, "shared" = from another scope
+  string owner = 14;  // owner scope (e.g. "@cp"), empty for local clips
+  int64 price_per_invoke = 15; // credit cost per invoke (0 = free)
 }
 
 message DependencySlot {


### PR DESCRIPTION
Add fields 13-15 to `ClipInfo` message for Clip Sharing:

- `source` (string): `""` for local, `"shared"` for cross-scope clips  
- `owner` (string): owner scope e.g. `"@cp"`, empty for local
- `price_per_invoke` (int64): credit cost per invoke, 0 = free

These fields are set by Cloud Hub when returning shared clips in `ListClips`.
Transparent to pinixd/providers — they never set these fields.

Part of Clip Sharing feature (epiral/pinix.ai#50).