### PR TITLE
chore: migrate pinix.ai URLs to pinixai.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://pinix.ai/logo.svg" alt="Pinix" width="120" />
+  <img src="https://pinixai.com/logo.svg" alt="Pinix" width="120" />
 </p>
 
 <h1 align="center">Pinix</h1>
@@ -53,7 +53,7 @@ pinix invoke todo list                          # see results
 open http://localhost:9000                       # open Console
 ```
 
-After `pinix login`, your local Clips are accessible from any device through pinix.ai Cloud Hub.
+After `pinix login`, your local Clips are accessible from any device through pinixai.com Cloud Hub.
 
 ## What You Get
 
@@ -63,7 +63,7 @@ When `pinix start` runs, you get a complete local capability stack:
 pinix start
   ├── Hub        routes invoke calls to the right Clip
   ├── Runtime    manages local Bun/TS Clip processes
-  ├── Registry   installs Clips from pinix.ai
+  ├── Registry   installs Clips from pinixai.com
   └── Console    web UI at localhost:9000
 ```
 
@@ -86,10 +86,10 @@ Your browser's login sessions, cookies, SSO, and intranet access work out of the
 - [x] **Clip Runtime** — install, run, and manage Bun/TS Clips locally
 - [x] **Hub Routing** — route invoke calls by alias, auto-discover by package name
 - [x] **Edge Clips** — BB-Browser, clipboard, screen, device APIs register automatically
-- [x] **Clip Web** — Clips ship their own Web UI, served at `{alias}.hub.pinix.ai`
+- [x] **Clip Web** — Clips ship their own Web UI, served at `{alias}.hub.pinixai.com`
 - [x] **Console** — manage Clips, view status, embed Clip Web via iframe
-- [x] **Registry** — search, install, publish Clips to pinix.ai
-- [x] **pinix.ai Cloud Hub** — cross-network routing, access Clips from any device
+- [x] **Registry** — search, install, publish Clips to pinixai.com
+- [x] **pinixai.com Cloud Hub** — cross-network routing, access Clips from any device
 - [x] **`pinix login`** — device code flow, auto-restarts daemon to connect Cloud Hub
 - [x] **Single binary** — one `pinix` binary: `start`, `stop`, `status`, `login`, `invoke`
 - [x] **Auto-connect** — reads saved token, connects to Cloud Hub automatically
@@ -128,7 +128,7 @@ pinix invoke twitter search --query "AI agent"
 
 103 commands across 36 platforms out of the box. Agent can also generate new site adapters autonomously.
 
-## Connect to pinix.ai
+## Connect to pinixai.com
 
 ```bash
 pinix login

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://pinix.ai/logo.svg" alt="Pinix" width="120" />
+  <img src="https://pinixai.com/logo.svg" alt="Pinix" width="120" />
 </p>
 
 <h1 align="center">Pinix</h1>
@@ -53,7 +53,7 @@ pinix invoke todo list                          # 查看结果
 open http://localhost:9000                       # 打开 Console
 ```
 
-`pinix login` 后，你的本地 Clips 通过 pinix.ai Cloud Hub 在任何设备上都可以访问。
+`pinix login` 后，你的本地 Clips 通过 pinixai.com Cloud Hub 在任何设备上都可以访问。
 
 ## 启动后你得到什么
 
@@ -86,10 +86,10 @@ $ pinix hub list
 - [x] **Clip Runtime** — 本地安装、运行和管理 Bun/TS Clips
 - [x] **Hub 路由** — 按 alias 路由 invoke，按 package name 自动发现
 - [x] **Edge Clips** — BB-Browser、clipboard、screen 等自动注册
-- [x] **Clip Web** — Clip 自带 Web UI，通过 `{alias}.hub.pinix.ai` 访问
+- [x] **Clip Web** — Clip 自带 Web UI，通过 `{alias}.hub.pinixai.com` 访问
 - [x] **Console** — 管理 Clips、查看状态、iframe 嵌入 Clip Web
-- [x] **Registry** — 搜索、安装、发布 Clips 到 pinix.ai
-- [x] **pinix.ai Cloud Hub** — 跨网络路由，从任何设备访问 Clips
+- [x] **Registry** — 搜索、安装、发布 Clips 到 pinixai.com
+- [x] **pinixai.com Cloud Hub** — 跨网络路由，从任何设备访问 Clips
 - [x] **`pinix login`** — device code flow，登录后自动重启 daemon 连接 Cloud Hub
 - [x] **单一 binary** — 一个 `pinix`：`start`、`stop`、`status`、`login`、`invoke`
 - [x] **自动连接** — 读取已保存 token，自动连 Cloud Hub
@@ -128,7 +128,7 @@ pinix invoke twitter search --query "AI agent"
 
 内置 103 个命令覆盖 36 个平台。Agent 还能自主生成新的 site adapter。
 
-## 连接 pinix.ai
+## 连接 pinixai.com
 
 ```bash
 pinix login

--- a/cmd/pinix/auth.go
+++ b/cmd/pinix/auth.go
@@ -388,14 +388,11 @@ func decodeAuthError(resp *http.Response, action string) error {
 // hubURLFromAuthServer derives the Hub URL from the auth server URL.
 // e.g. "https://api.pinixai.com" → "https://hub.pinixai.com"
 //
-//	"https://api.pinix.ai" → "https://hub.pinix.ai"
+//	"https://api.pinixai.com" → "https://hub.pinixai.com"
 func hubURLFromAuthServer(serverURL string) string {
 	serverURL = strings.TrimRight(serverURL, "/")
 	if strings.Contains(serverURL, "api.pinixai.com") {
 		return "https://hub.pinixai.com"
-	}
-	if strings.Contains(serverURL, "api.pinix.ai") {
-		return "https://hub.pinix.ai"
 	}
 	// Generic: replace "api." with "hub."
 	return strings.Replace(serverURL, "://api.", "://hub.", 1)

--- a/cmd/pinix/invoke.go
+++ b/cmd/pinix/invoke.go
@@ -29,8 +29,8 @@ Arguments after <clip> are the command path (supports sub-commands):
   pinix invoke memex schema list --topLevel true
 
 Connection flags can appear anywhere in the command:
-  pinix invoke todo list --server https://hub.pinix.ai --auth-token <token>
-  pinix invoke --server https://hub.pinix.ai todo list
+  pinix invoke todo list --server https://hub.pinixai.com --auth-token <token>
+  pinix invoke --server https://hub.pinixai.com todo list
 
 Help:
   pinix invoke <clip> --help         Show all commands for a Clip

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,7 +150,7 @@ Pinix V2 使用三种来源前缀标识 Clip 包：
 
 当 CLI 收到 `@scope/name` 格式的来源时：
 
-1. CLI 从 flag `--registry` > 环境变量 `PINIX_REGISTRY` > `~/.pinix/client.json` 中的 `registry` 字段 > 默认值 `https://api.pinix.ai` 解析 Registry URL。
+1. CLI 从 flag `--registry` > 环境变量 `PINIX_REGISTRY` > `~/.pinix/client.json` 中的 `registry` 字段 > 默认值 `https://api.pinixai.com` 解析 Registry URL。
 2. 构造内部规范形式 `registry:<url>#@scope/name[@version]`，发送给 Hub。
 3. Runtime 从 Registry 下载 tarball、校验 shasum、解压、`bun install`。
 
@@ -188,14 +188,14 @@ Runtime 可以连接到远端 Cloud Hub，通过 `ProviderStream` + `RuntimeStre
 
 ```bash
 # 命令行参数
-pinixd --hub https://hub.pinix.ai --hub-token <jwt>
+pinixd --hub https://hub.pinixai.com --hub-token <jwt>
 
 # 环境变量
-PINIX_HUB=https://hub.pinix.ai
+PINIX_HUB=https://hub.pinixai.com
 PINIX_HUB_TOKEN=<jwt>
 
 # 持久化配置
-pinix config set hub https://hub.pinix.ai
+pinix config set hub https://hub.pinixai.com
 pinix config set hub-token <jwt>
 ```
 
@@ -204,7 +204,7 @@ pinix config set hub-token <jwt>
 ### Registry 配置
 
 ```bash
-pinix config set registry https://api.pinix.ai
+pinix config set registry https://api.pinixai.com
 ```
 
 ## 当前代码里的运行模式

--- a/docs/clip-distribution.md
+++ b/docs/clip-distribution.md
@@ -73,8 +73,8 @@ github/user/repo     -> GitHub                   [github]
 ## Registry 架构
 
 ```
-registry.pinix.ai    -> API 地址（pinix add / publish / search 解析到这里）
-clips.pinix.ai       -> Web 网站（人在浏览器浏览/发现 Clip）
+registry.pinixai.com    -> API 地址（pinix add / publish / search 解析到这里）
+clips.pinixai.com       -> Web 网站（人在浏览器浏览/发现 Clip）
 ```
 
 类比 npm：
@@ -89,13 +89,13 @@ www.npmjs.com        -> 网站
 
 ```
 # 包查询
-GET  registry.pinix.ai/packages/@scope/name              -> 包信息（所有版本）
-GET  registry.pinix.ai/packages/@scope/name/:version      -> 特定版本
-GET  registry.pinix.ai/packages/@scope/name/:version/download -> 下载 tarball
-GET  registry.pinix.ai/search?q=:query&domain=:domain     -> 搜索
+GET  registry.pinixai.com/packages/@scope/name              -> 包信息（所有版本）
+GET  registry.pinixai.com/packages/@scope/name/:version      -> 特定版本
+GET  registry.pinixai.com/packages/@scope/name/:version/download -> 下载 tarball
+GET  registry.pinixai.com/search?q=:query&domain=:domain     -> 搜索
 
 # 发布
-PUT  registry.pinix.ai/packages/@scope/name/versions      -> 发布新版本
+PUT  registry.pinixai.com/packages/@scope/name/versions      -> 发布新版本
 
 # 认证
 # CLI 登录后拿到 JWT，Registry 和 API 共用同一套 token
@@ -105,7 +105,7 @@ PUT  registry.pinix.ai/packages/@scope/name/versions      -> 发布新版本
 
 ```bash
 # 默认（不用配）
-pinix add @cp/todo  -> registry.pinix.ai
+pinix add @cp/todo  -> registry.pinixai.com
 
 # 企业自建（可选）
 pinix config set registry https://registry.my-company.com

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -55,7 +55,7 @@ Hub 是路由中心，所有 Clip 在 Hub 上被发现和调用。
 
 - Hub 是唯一路由器。Agent 通过 Hub 调用 Clip，不直接连 Clip。
 - Hub 管理 alias 分配——每个 Clip 在 Hub 上有唯一别名。
-- `pinixd --port 9000` 启动本地 Hub。Cloud Hub（hub.pinix.ai）提供云端版本。
+- `pinixd --port 9000` 启动本地 Hub。Cloud Hub（hub.pinixai.com）提供云端版本。
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -129,7 +129,7 @@ go build -o pinix ./cmd/pinix
 
 ### 配置 Registry
 
-默认 Registry 是 `https://api.pinix.ai`。可以通过 `pinix config` 修改：
+默认 Registry 是 `https://api.pinixai.com`。可以通过 `pinix config` 修改：
 
 ```bash
 ./pinix config set registry https://your-registry.example.com
@@ -249,10 +249,10 @@ Cursor 的 MCP 配置界面使用同样的 `command` 和 `args` 即可。
 
 ```bash
 # 命令行
-./pinixd --port 9001 --hub https://hub.pinix.ai --hub-token <jwt>
+./pinixd --port 9001 --hub https://hub.pinixai.com --hub-token <jwt>
 
 # 或持久化配置
-./pinix config set hub https://hub.pinix.ai
+./pinix config set hub https://hub.pinixai.com
 ./pinix config set hub-token <jwt>
 ./pinixd --port 9001
 ```

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -209,8 +209,8 @@ sequenceDiagram
     participant Registry as Pinix Registry
     participant Clip as clip-todo (Bun)
 
-    CLI->>CLI: normalizeAddSource("@pinixai/todo") → "registry:https://api.pinix.ai#@pinixai/todo"
-    CLI->>Hub: RPC AddClip {source:"registry:https://api.pinix.ai#@pinixai/todo"}
+    CLI->>CLI: normalizeAddSource("@pinixai/todo") → "registry:https://api.pinixai.com#@pinixai/todo"
+    CLI->>Hub: RPC AddClip {source:"registry:https://api.pinixai.com#@pinixai/todo"}
     Hub->>Hub: 校验 super_token (Authorization header)
     Hub->>Hub: ReserveAlias → auto-generate "todo-a3f1"
     Hub->>Runtime: handler.handleAdd()


### PR DESCRIPTION
pinix.ai domain deprecated, 301 redirects to pinixai.com.

**P0 (production code):**
- `auth.go`: remove `api.pinix.ai` special case from `hubURLFromAuthServer`
- `invoke.go`: update help text hub URL

**P1 (README):**
- Logo URL `pinix.ai/logo.svg` → `pinixai.com/logo.svg`
- All Cloud Hub references

**P2 (docs):**
- architecture, getting-started, concepts, protocol, clip-distribution

Build verified: `go build ./cmd/pinix && go build ./cmd/pinixd`